### PR TITLE
fix: add support for marking array response in diff viewer

### DIFF
--- a/lib/compute-lines.d.ts
+++ b/lib/compute-lines.d.ts
@@ -18,6 +18,7 @@ export interface DiffInformation {
     value?: string | DiffInformation[];
     lineNumber?: number;
     type?: DiffType;
+    flattenPath?: string;
 }
 export interface LineInformation {
     left?: DiffInformation;
@@ -29,6 +30,7 @@ export interface ComputedLineInformation {
 }
 interface DiffChange extends diff.Change {
     noised?: boolean;
+    flattenPath?: string;
 }
 export interface ComputedDiffInformation {
     left?: DiffInformation[];
@@ -39,6 +41,18 @@ export interface JsDiffChangeObject {
     removed?: boolean;
     value?: string;
     noised?: boolean;
+    flattenPath?: string;
 }
-declare const computeLineInformation: (oldString: string, newString: string, noise: string[], disableWordDiff?: boolean, compareMethod?: string | ((oldStr: string, newStr: string) => DiffChange[]), linesOffset?: number) => ComputedLineInformation;
-export { computeLineInformation };
+/**
+ * Computes line-wise diff information from two input strings. If JSON, uses CompareJSON,
+ * otherwise uses a simple line diff. Also incorporates flattenPath from CompareJSON results.
+ *
+ * @param oldString Old string to compare.
+ * @param newString New string to compare with old string.
+ * @param noise Noise array for ignoring certain paths.
+ * @param disableWordDiff Flag to enable/disable word diff.
+ * @param compareMethod JsDiff method.
+ * @param linesOffset Starting line number offset.
+ */
+export declare const computeLineInformation: (oldString: string, newString: string, noise: string[], disableWordDiff?: boolean, compareMethod?: string | ((oldStr: string, newStr: string) => DiffChange[]), linesOffset?: number) => ComputedLineInformation;
+export {};

--- a/lib/compute-lines.js
+++ b/lib/compute-lines.js
@@ -39,8 +39,7 @@ var DiffMethod;
     DiffMethod["CSS"] = "diffCss";
 })(DiffMethod = exports.DiffMethod || (exports.DiffMethod = {}));
 /**
- * Splits diff text by new line and computes final list of diff lines based on
- * conditions.
+ * Splits diff text by new line and computes final list of diff lines based on conditions.
  *
  * @param value Diff text from the js diff module.
  */
@@ -55,7 +54,6 @@ const constructLines = (value) => {
     const lines = value.split('\n');
     const isAllEmpty = lines.every((val) => !val);
     if (isAllEmpty) {
-        // This is to avoid added an extra new line in the UI.
         if (lines.length === 2) {
             return [];
         }
@@ -110,48 +108,45 @@ const computeDiff = (oldValue, newValue, compareMethod = DiffMethod.CHARS) => {
     });
     return computedDiff;
 };
-function noiseDiffArray(expectedObj, actualObj, key) {
+const sanitizeInput = (input) => {
+    return input.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\/g, '');
+};
+function noiseDiffArray(expectedObj, actualObj, key, flattenKeyPath = '') {
     const result = [];
     const expectedLines = constructLines(JSON.stringify(expectedObj, null, 2));
     const actualLines = constructLines(JSON.stringify(actualObj, null, 2));
-    expectedLines.map((el, elIndex) => {
+    expectedLines.forEach((el, elIndex) => {
         // to handle common length of both lines array.
         if (elIndex < actualLines.length) {
             // add key only to the first line before and after seperator.
             if (elIndex === 0) {
                 actualLines[elIndex] = sanitizeInput(actualLines[elIndex]);
                 el = sanitizeInput(el);
-                result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}${actualLines[elIndex]}` });
+                result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}${actualLines[elIndex]}`, flattenPath: flattenKeyPath });
             }
             else {
                 actualLines[elIndex] = sanitizeInput(actualLines[elIndex]);
                 el = sanitizeInput(el);
-                result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_  ${actualLines[elIndex]}` });
+                result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_  ${actualLines[elIndex]}`, flattenPath: flattenKeyPath });
             }
         }
-        // lines in expectedObj is greater than actualObj and add key string only to the first line.
-        // example: expectedObj: "", actualObj: "[1, 2, true]"
         else if (elIndex === 0) {
             el = sanitizeInput(el);
-            result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}` });
+            result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}`, flattenPath: flattenKeyPath });
         }
         else {
             el = sanitizeInput(el);
-            result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_` });
+            result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_`, flattenPath: flattenKeyPath });
         }
     });
     for (let indx = expectedLines.length; indx < actualLines.length; indx++) {
-        // lines in actual object is greater than expected object.
-        // example: expectedObj: "[1, 2, true]", actualObj: ""
         if (indx === 0) {
             actualLines[indx] = sanitizeInput(actualLines[indx]);
-            // expectedLines[indx] = sanitizeInput(expectedLines[indx])
-            result.push({ count: -2, noised: true, value: `${key}_keploy_|_keploy_${key}${actualLines[indx]}` });
+            result.push({ count: -2, noised: true, value: `${key}_keploy_|_keploy_${key}${actualLines[indx]}`, flattenPath: flattenKeyPath });
         }
         else {
             actualLines[indx] = sanitizeInput(actualLines[indx]);
-            // expectedLines[indx] = sanitizeInput(expectedLines[indx])
-            result.push({ count: -2, noised: true, value: `_keploy_|_keploy_  ${actualLines[indx]}` });
+            result.push({ count: -2, noised: true, value: `_keploy_|_keploy_  ${actualLines[indx]}`, flattenPath: flattenKeyPath });
         }
     }
     return result;
@@ -160,300 +155,274 @@ function CompareJSON(expectedStr, actualStr, noise, flattenKeyPath) {
     const result = [];
     const expectedJSON = JSON.parse(expectedStr);
     const actualJSON = JSON.parse(actualStr);
-  
     // Type mismatch
     if (typeof expectedJSON !== typeof actualJSON) {
-      if (!noise.includes(flattenKeyPath)) {
-        result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-        result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
+        if (!noise.includes(flattenKeyPath)) {
+            result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
+            result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2), flattenPath: flattenKeyPath });
+            return result;
+        }
+        const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+        output.forEach((el) => {
+            result.push(Object.assign(Object.assign({}, el), { noised: true }));
+        });
         return result;
-      }
-      const output = noiseDiffArray(expectedJSON, actualJSON, '');
-      output.map((el) => {
-        result.push({ ...el, noised: true });
-      });
-      return result;
     }
-  
     switch (typeof expectedJSON) {
-      case 'string': {
-        if (expectedJSON === actualJSON) {
-          result.push({ count: -1, value: expectedJSON });
-          return result;
-        }
-        if (noise.includes(flattenKeyPath)) {
-          const output = noiseDiffArray(expectedJSON, actualJSON, '');
-          output.map((el) => {
-            result.push({ ...el, noised: true });
-          });
-        } else {
-          result.push({ count: -1, removed: true, value: expectedJSON });
-          result.push({ count: -1, added: true, value: actualJSON });
-          return result;
-        }
-        break;
-      }
-      case 'number': {
-        if (expectedJSON === actualJSON) {
-          result.push({ count: -1, value: expectedStr });
-          return result;
-        }
-        if (noise.includes(flattenKeyPath)) {
-          const output = noiseDiffArray(expectedJSON, actualJSON, '');
-          output.map((el) => {
-            result.push({ ...el, noised: true });
-          });
-        } else {
-          result.push({ count: -1, removed: true, value: expectedStr });
-          result.push({ count: -1, added: true, value: actualStr });
-          return result;
-        }
-        break;
-      }
-      case 'boolean': {
-        if (expectedStr === actualStr) {
-          result.push({ count: -1, value: expectedStr });
-          return result;
-        }
-        if (noise.includes(flattenKeyPath)) {
-          const output = noiseDiffArray(expectedJSON, actualJSON, '');
-          output.map((el) => {
-            result.push({ ...el, noised: true });
-          });
-        } else {
-          result.push({ count: -1, removed: true, value: expectedStr });
-          result.push({ count: -1, added: true, value: actualStr });
-          return result;
-        }
-        break;
-      }
-      case 'object': {
-        if (noise.includes(flattenKeyPath)) {
-          const output = noiseDiffArray(expectedJSON, actualJSON, '');
-          output.map((el) => {
-            result.push({ ...el, noised: true });
-          });
-          return result;
-        }
-  
-        if (Array.isArray(expectedJSON) && Array.isArray(actualJSON)) {
-          result.push({ count: -1, value: '[' });
-  
-          expectedJSON.map((el, elIndx) => {
-            if (elIndx < actualJSON.length) {
-              const nextPath = `${flattenKeyPath}[${elIndx}]`;
-              const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, nextPath);
-              output.map((res) => {
-                res.value = `  ${res.value}`;
-                if (res.value[res.value.length - 1] != ',' && res.value.trim() !== "{" && !res.value.endsWith("_keploy_|_keploy_")) {
-                  res.value += ',';
-                }
-                result.push(res);
-              });
-            } else {
-              const lines = constructLines(JSON.stringify(el, null, 2));
-              lines.map((line) => {
-                line = `  ${line}`;
-                if (line.trim() !== "{") {
-                  line = line + ",";
-                }
-                result.push({ count: -1, removed: true, value: line });
-              });
+        case 'string': {
+            if (expectedJSON === actualJSON) {
+                result.push({ count: -1, value: expectedJSON, flattenPath: flattenKeyPath });
+                return result;
             }
-          });
-  
-          for (let indx = expectedJSON.length; indx < actualJSON.length; indx++) {
-            if (result[result.length - 1].removed) {
-              result.push({ count: -3, value: "" });
+            if (noise.includes(flattenKeyPath)) {
+                const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+                output.forEach((el) => {
+                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
+                });
             }
-            const lines = constructLines(JSON.stringify(actualJSON[indx], null, 2));
-            lines.map((line) => {
-              line = `  ${line}`;
-              if (line.trim() !== "{") {
-                line = line + ",";
-              }
-              result.push({ count: -1, added: true, value: line });
-            });
-          }
-          result.push({ count: -1, value: ']' });
-        } else if (
-          expectedJSON !== null &&
-          expectedJSON !== undefined &&
-          actualJSON !== null &&
-          actualJSON !== undefined &&
-          !Array.isArray(expectedJSON) &&
-          !Array.isArray(actualJSON)
-        ) {
-          result.push({ count: -1, value: '{' });
-  
-          for (const key in expectedJSON) {
-            if (key in actualJSON) {
-              const valueExpectedObj = expectedJSON[key];
-              const valueActualObj = actualJSON[key];
-              const nextPath = flattenKeyPath === "" ? `${key}` : `${flattenKeyPath}.${key}`;
-              const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
-  
-              if (valueActualObj == null && valueExpectedObj == null) {
-                result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},` });
-              } else if (
-                typeof valueExpectedObj === 'object' &&
-                (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))
-              ) {
-                if (noise.includes(nextPath)) {
-                  const nOutput = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
-                  nOutput.map((el) => {
-                    result.push({ ...el, noised: true });
-                  });
-                } else {
-                  result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
-                  result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
-                }
-              } else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
-                result.push({ count: -1, value: `  ${key}: [\n` });
-                output.map((res, resIndx) => {
-                  if (resIndx > 0) {
-                    res.value = `  ${res.value}`;
-                    if (res.count === -2) {
-                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                      const tagLength = '_keploy_|_keploy_'.length;
-                      res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
-                    }
-                    result.push(res);
-                  }
+            else {
+                result.push({ count: -1, removed: true, value: expectedJSON, flattenPath: flattenKeyPath });
+                result.push({ count: -1, added: true, value: actualJSON, flattenPath: flattenKeyPath });
+                return result;
+            }
+            break;
+        }
+        case 'number': {
+            if (expectedJSON === actualJSON) {
+                result.push({ count: -1, value: expectedStr, flattenPath: flattenKeyPath });
+                return result;
+            }
+            if (noise.includes(flattenKeyPath)) {
+                const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+                output.forEach((el) => {
+                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
                 });
-              } else if (typeof valueExpectedObj === 'object') {
-                result.push({ count: -1, value: `  ${key}: {\n` });
-                output.map((res, resIndx) => {
-                  if (resIndx > 0) {
-                    if (res.count === -2) {
-                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                      const tagLength = '_keploy_|_keploy_'.length;
-                      res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`
-                    } else {
-                      res.value = `  ${res.value}`;
-                    }
-                    result.push(res);
-                  }
+            }
+            else {
+                result.push({ count: -1, removed: true, value: expectedStr, flattenPath: flattenKeyPath });
+                result.push({ count: -1, added: true, value: actualStr, flattenPath: flattenKeyPath });
+                return result;
+            }
+            break;
+        }
+        case 'boolean': {
+            if (expectedStr === actualStr) {
+                result.push({ count: -1, value: expectedStr, flattenPath: flattenKeyPath });
+                return result;
+            }
+            if (noise.includes(flattenKeyPath)) {
+                const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+                output.forEach((el) => {
+                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
                 });
-              } else {
-                if (output.length === 1) {
-                  if (output[0].count === -1) {
-                    result.push({ count: -1, value: `  ${key}: ${output[0].value},` });
-                  } else {
-                    const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
-                    const tagLength = '_keploy_|_keploy_'.length;
-                    result.push({
-                      count: -2,
-                      noised: true,
-                      value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_` + `  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},`
+            }
+            else {
+                result.push({ count: -1, removed: true, value: expectedStr, flattenPath: flattenKeyPath });
+                result.push({ count: -1, added: true, value: actualStr, flattenPath: flattenKeyPath });
+                return result;
+            }
+            break;
+        }
+        case 'object': {
+            if (noise.includes(flattenKeyPath)) {
+                const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+                output.forEach((el) => {
+                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
+                });
+                return result;
+            }
+            // Both arrays
+            if (Array.isArray(expectedJSON) && Array.isArray(actualJSON)) {
+                result.push({ count: -1, value: '[', flattenPath: flattenKeyPath });
+                expectedJSON.forEach((el, elIndx) => {
+                    const elementPath = flattenKeyPath === "" ? `[${elIndx}]` : `${flattenKeyPath}[${elIndx}]`;
+                    if (elIndx < actualJSON.length) {
+                        const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, elementPath);
+                        output.forEach((res) => {
+                            res.value = `  ${res.value}`;
+                            if (res.value[res.value.length - 1] !== ',' &&
+                                res.value.trim() !== "{" &&
+                                !res.value.endsWith("_keploy_|_keploy_")) {
+                                res.value += ',';
+                            }
+                            // ensure each element line has correct flattenPath
+                            res.flattenPath = res.flattenPath || elementPath;
+                            result.push(res);
+                        });
+                    }
+                    else {
+                        const lines = constructLines(JSON.stringify(el, null, 2));
+                        lines.forEach((line) => {
+                            let modifiedLine = `  ${line}`;
+                            if (modifiedLine.trim() !== "{") {
+                                modifiedLine = modifiedLine + ",";
+                            }
+                            result.push({ count: -1, removed: true, value: modifiedLine, flattenPath: elementPath });
+                        });
+                    }
+                });
+                for (let indx = expectedJSON.length; indx < actualJSON.length; indx++) {
+                    if (result[result.length - 1].removed) {
+                        result.push({ count: -3, value: "", flattenPath: flattenKeyPath });
+                    }
+                    const elementPath = flattenKeyPath === "" ? `[${indx}]` : `${flattenKeyPath}[${indx}]`;
+                    const lines = constructLines(JSON.stringify(actualJSON[indx], null, 2));
+                    lines.forEach((line) => {
+                        let modifiedLine = `  ${line}`;
+                        if (modifiedLine.trim() !== "{") {
+                            modifiedLine = modifiedLine + ",";
+                        }
+                        result.push({ count: -1, added: true, value: modifiedLine, flattenPath: elementPath });
                     });
-                  }
-                } else {
-                  result.push({
-                    count: output[0].count,
-                    removed: output[0].removed,
-                    added: output[0].added,
-                    value: `  ${key}: ${output[0].value},`,
-                    noised: output[0].noised
-                  });
-                  result.push({
-                    count: output[1].count,
-                    removed: output[1].removed,
-                    added: output[1].added,
-                    value: `  ${key}: ${output[1].value},`,
-                    noised: output[1].noised
-                  });
                 }
-              }
-            } else {
-              result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},` });
+                result.push({ count: -1, value: ']', flattenPath: flattenKeyPath });
             }
-          }
-  
-          for (const key in actualJSON) {
-            if (result[result.length - 1].removed) {
-              result.push({ count: -3, value: "" })
+            // Both objects
+            else if (expectedJSON !== null && expectedJSON !== undefined &&
+                actualJSON !== null && actualJSON !== undefined &&
+                !Array.isArray(expectedJSON) && !Array.isArray(actualJSON)) {
+                result.push({ count: -1, value: '{', flattenPath: flattenKeyPath });
+                for (const key in expectedJSON) {
+                    const nextPath = flattenKeyPath === "" ? `${key}` : `${flattenKeyPath}.${key}`;
+                    if (key in actualJSON) {
+                        const valueExpectedObj = expectedJSON[key];
+                        const valueActualObj = actualJSON[key];
+                        const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
+                        if (valueActualObj == null && valueExpectedObj == null) {
+                            result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},`, flattenPath: nextPath });
+                        }
+                        else if (typeof valueExpectedObj === 'object' && (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))) {
+                            if (noise.includes(nextPath)) {
+                                const nOutput = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `, nextPath);
+                                nOutput.forEach((el) => {
+                                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
+                                });
+                            }
+                            else {
+                                result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},`, flattenPath: nextPath });
+                                result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},`, flattenPath: nextPath });
+                            }
+                        }
+                        else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
+                            result.push({ count: -1, value: `  ${key}: [\n`, flattenPath: nextPath });
+                            output.forEach((res, resIndx) => {
+                                if (resIndx > 0) {
+                                    res.value = `  ${res.value}`;
+                                    if (res.count === -2) {
+                                        const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                                        const tagLength = '_keploy_|_keploy_'.length;
+                                        res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
+                                    }
+                                    res.flattenPath = res.flattenPath || nextPath;
+                                    result.push(res);
+                                }
+                            });
+                        }
+                        else if (typeof valueExpectedObj === 'object') {
+                            result.push({ count: -1, value: `  ${key}: {\n`, flattenPath: nextPath });
+                            output.forEach((res, resIndx) => {
+                                if (resIndx > 0) {
+                                    if (res.count === -2) {
+                                        const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                                        const tagLength = '_keploy_|_keploy_'.length;
+                                        res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`;
+                                    }
+                                    else {
+                                        res.value = `  ${res.value}`;
+                                    }
+                                    res.flattenPath = res.flattenPath || nextPath;
+                                    result.push(res);
+                                }
+                            });
+                        }
+                        else {
+                            // primitive values
+                            if (output.length === 1) {
+                                if (output[0].count === -1) {
+                                    result.push({ count: -1, value: `  ${key}: ${output[0].value},`, flattenPath: nextPath });
+                                }
+                                else {
+                                    const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
+                                    const tagLength = '_keploy_|_keploy_'.length;
+                                    result.push({
+                                        count: -2,
+                                        noised: true,
+                                        value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},`,
+                                        flattenPath: nextPath
+                                    });
+                                }
+                            }
+                            else {
+                                result.push({
+                                    count: output[0].count,
+                                    removed: output[0].removed,
+                                    added: output[0].added,
+                                    value: `  ${key}: ${output[0].value},`,
+                                    noised: output[0].noised,
+                                    flattenPath: nextPath
+                                });
+                                result.push({
+                                    count: output[1].count,
+                                    removed: output[1].removed,
+                                    added: output[1].added,
+                                    value: `  ${key}: ${output[1].value},`,
+                                    noised: output[1].noised,
+                                    flattenPath: nextPath
+                                });
+                            }
+                        }
+                    }
+                    else {
+                        // key missing in actual
+                        result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},`, flattenPath: flattenKeyPath });
+                    }
+                }
+                for (const key in actualJSON) {
+                    if (result[result.length - 1].removed) {
+                        result.push({ count: -3, value: "", flattenPath: flattenKeyPath });
+                    }
+                    if (!(key in expectedJSON)) {
+                        result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},`, flattenPath: flattenKeyPath });
+                    }
+                }
+                result.push({ count: -1, value: '}', flattenPath: flattenKeyPath });
             }
-            if (!(key in expectedJSON)) {
-              result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},` });
+            else if (expectedJSON == null && actualJSON == null) {
+                result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
             }
-          }
-          result.push({ count: -1, value: '}' });
-        } else if (expectedJSON == null && actualJSON == null) {
-          result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2) });
-        } else {
-          result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-          result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
+            else {
+                result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
+                result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2), flattenPath: flattenKeyPath });
+            }
+            break;
         }
-  
-        break;
-      }
     }
     return result;
 }
 /**
- * [TODO]: Think about moving common left and right value assignment to a
- * common place. Better readability?
- *
- * Computes line wise information based in the js diff information passed. Each
- * line contains information about left and right section. Left side denotes
- * deletion and right side denotes addition.
+ * Computes line-wise diff information from two input strings. If JSON, uses CompareJSON,
+ * otherwise uses a simple line diff. Also incorporates flattenPath from CompareJSON results.
  *
  * @param oldString Old string to compare.
  * @param newString New string to compare with old string.
+ * @param noise Noise array for ignoring certain paths.
  * @param disableWordDiff Flag to enable/disable word diff.
- * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
- * @param linesOffset line number to start counting from
+ * @param compareMethod JsDiff method.
+ * @param linesOffset Starting line number offset.
  */
-const sanitizeInput = (input) => {
-    return input.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\/g, '');
-};
 const computeLineInformation = (oldString, newString, noise, disableWordDiff = false, compareMethod = DiffMethod.CHARS, linesOffset = 0) => {
-    // oldString = sanitizeInput(oldString);
-    // newString = sanitizeInput(newString);
-    // let noiseTmp:string[] = []
-    // for(let i=0; i<noise.length ;i++){
-    // 	noiseTmp.push(noise[i])
-    // }
-    // let expectedStr =  addNoiseTags(oldString, "keploy.noise.l", noiseTmp, false)[0] as string
-    // let actualStr = addNoiseTags(newString, "keploy.noise.r", noise, false)[0]  as string
-    let diffArray;
-    var validJSON = "plain";
     if (noise === null || noise === undefined) {
         noise = [];
     }
+    let diffArray;
+    let validJSON = "plain";
     try {
         JSON.parse(oldString);
         JSON.parse(newString);
-        // if (noise === null || noise === undefined){
-        //   noise = []
-        // }
-        // diffArray = CompareJSON(
-        //   oldString.trimRight(),
-        //   newString.trimRight(),
-        //   noise,
-        //   "body",
-        // )
         validJSON = "JSON";
     }
     catch (e) {
-        // if ( noise==null || noise.length==0 || (noise.length>0 && !noise.includes("body"))){
-        //   diffArray = diff.diffLines(
-        //     oldString.trimRight(),
-        //     newString.trimRight(),
-        //     {
-        //       newlineIsToken: true,
-        //       ignoreWhitespace: false,
-        //       ignoreCase: false,
-        //     },
-        //   )
-        //   if (diffArray.length ===1 ){
-        //     diffArray[0].count = -1
-        //   }
-        // }
-        // else{
-        //   diffArray = noiseDiffArray(oldString, newString, "")
-        // }
+        // fall back to plain text diff if not valid JSON
     }
     if (validJSON === 'plain') {
         if (noise == null || noise.length == 0 || (noise.length > 0 && !noise.includes("body"))) {
@@ -465,68 +434,36 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
             if (diffArray.length === 1) {
                 diffArray[0].count = -1;
             }
+            diffArray.forEach(d => {
+                if (d.flattenPath === undefined) {
+                    d.flattenPath = "";
+                }
+            });
         }
         else {
-            diffArray = noiseDiffArray(oldString, newString, "");
+            diffArray = noiseDiffArray(oldString, newString, "", "");
         }
     }
     else {
         diffArray = CompareJSON(oldString.trimRight(), newString.trimRight(), noise, "");
     }
-    // const diffArray = CompareJSON(
-    // 	 oldString.trimRight(),
-    // 	 newString.trimRight(),
-    // 	 noise,
-    // 	 'body',
-    //   // {
-    //   // 	newlineIsToken: true,
-    //   // 	ignoreWhitespace: false,
-    //   // 	ignoreCase: false,
-    //   // },
-    // );
-    // [
-    // 	{
-    // 		added: Boolean,
-    // 		removed: Boolean,
-    // 		count: 1234,
-    // 		value: "{ "name": "ritik,"\n "age ": 21"
-    // 	},
-    // 	{
-    // 		removed: true,
-    // 		count: 1,
-    // 		value: "contact: "keploy.noise.l78278782892", \n"
-    // 	},
-    // 	{
-    // 		added: true,
-    // 		count: 1,
-    // 		value: "contact: "keploy.noise.r7827212052", \n"
-    // 	},
-    // ]
-    // console.log(diffArray);
-    // diffArray.forEach((element, elIndex) => {
-    // 	if (element.value.includes("keploy.noise")){
-    // 		element.added = undefined
-    // 		element.removed = undefined
-    // 	}
-    // });
-    // console.log(noise);
     let rightLineNumber = linesOffset;
     let leftLineNumber = linesOffset;
     let lineInformation = [];
     let counter = 0;
     const diffLines = [];
     const ignoreDiffIndexes = [];
-    const getLineInformation = (value, diffIndex, added, removed, noised, // Add noised parameter
-    evaluateOnlyFirstLine, LineIndexTobeReturned) => {
+    const getLineInformation = (value, diffIndex, added, removed, noised, evaluateOnlyFirstLine, LineIndexTobeReturned) => {
         const lines = constructLines(value);
         return lines.map((line, lineIndex) => {
-            const left = {};
-            const right = {};
             if (ignoreDiffIndexes.includes(`${diffIndex}-${lineIndex}`)
                 || (evaluateOnlyFirstLine && lineIndex !== 0) || diffArray[diffIndex].count === -3) {
                 return undefined;
             }
-            if (added || removed) { // Include noised in the condition
+            const left = {};
+            const right = {};
+            const currentFlattenPath = diffArray[diffIndex].flattenPath || "";
+            if (added || removed) {
                 if (!diffLines.includes(counter)) {
                     diffLines.push(counter);
                 }
@@ -535,6 +472,7 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
                     left.lineNumber = leftLineNumber;
                     left.type = DiffType.REMOVED;
                     left.value = line || ' ';
+                    left.flattenPath = currentFlattenPath;
                     const nextDiff = diffArray[diffIndex + 1];
                     if (nextDiff && nextDiff.added) {
                         const nextDiffLines = constructLines(nextDiff.value)[lineIndex];
@@ -542,18 +480,23 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
                             lines.push(' ');
                         }
                         if (nextDiffLines) {
-                            const { value: rightValue, lineNumber, type, } = getLineInformation(nextDiff.value, diffIndex, true, false, nextDiff.noised // Pass noised
-                            )[lineIndex].right;
-                            ignoreDiffIndexes.push(`${diffIndex + 1}-${lineIndex}`);
-                            right.lineNumber = lineNumber;
-                            right.type = type;
-                            if (disableWordDiff) {
-                                right.value = rightValue;
-                            }
-                            else {
-                                const computedDiff = computeDiff(line, rightValue, compareMethod);
-                                right.value = computedDiff.right;
-                                left.value = computedDiff.left;
+                            const nextLineInfo = getLineInformation(nextDiff.value, diffIndex + 1, true, false, nextDiff.noised);
+                            const nextInfo = nextLineInfo[lineIndex];
+                            if (nextInfo && nextInfo.right) {
+                                ignoreDiffIndexes.push(`${diffIndex + 1}-${lineIndex}`);
+                                right.lineNumber = nextInfo.right.lineNumber;
+                                right.type = nextInfo.right.type;
+                                right.flattenPath = nextDiff.flattenPath || "";
+                                if (disableWordDiff) {
+                                    right.value = nextInfo.right.value;
+                                }
+                                else {
+                                    const computedDiff = computeDiff(line, nextInfo.right.value, compareMethod);
+                                    computedDiff.left.forEach(l => { l.flattenPath = currentFlattenPath; });
+                                    computedDiff.right.forEach(r => { r.flattenPath = currentFlattenPath; });
+                                    right.value = computedDiff.right;
+                                    left.value = computedDiff.left;
+                                }
                             }
                         }
                     }
@@ -563,9 +506,11 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
                     right.lineNumber = rightLineNumber;
                     right.type = DiffType.ADDED;
                     right.value = line;
+                    right.flattenPath = currentFlattenPath;
                 }
             }
             else {
+                // default lines
                 if (diffArray[diffIndex].count === -1 || diffArray[diffIndex].count >= 0) {
                     leftLineNumber += 1;
                     rightLineNumber += 1;
@@ -575,6 +520,8 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
                     right.type = DiffType.DEFAULT;
                     left.value = line;
                     right.value = line;
+                    left.flattenPath = currentFlattenPath;
+                    right.flattenPath = currentFlattenPath;
                     if (noised) {
                         left.type = DiffType.NOISED;
                         right.type = DiffType.NOISED;
@@ -591,6 +538,8 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
                     right.type = DiffType.DEFAULT;
                     left.value = line.substring(0, tagStartIndex);
                     right.value = line.substring(tagStartIndex + tagLength);
+                    left.flattenPath = currentFlattenPath;
+                    right.flattenPath = currentFlattenPath;
                     if (noised) {
                         left.type = DiffType.NOISED;
                         right.type = DiffType.NOISED;
@@ -599,17 +548,14 @@ const computeLineInformation = (oldString, newString, noise, disableWordDiff = f
             }
             counter += 1;
             return { right, left };
-        }).filter(Boolean);
+        }).filter((item) => Boolean(item));
     };
-    diffArray.forEach(({ added, removed, value, noised }, index) => {
+    diffArray.forEach(({ added, removed, value, noised, flattenPath }, index) => {
         lineInformation = [
             ...lineInformation,
             ...getLineInformation(value, index, added, removed, noised),
         ];
     });
-    // if (lineInformation.length === 1) {
-    //   lineInformation.push({left: {value: "", lineNumber: 2, type:DiffType.DEFAULT}})
-    // }
     return {
         lineInformation,
         diffLines,

--- a/lib/compute-lines.js
+++ b/lib/compute-lines.js
@@ -160,293 +160,234 @@ function CompareJSON(expectedStr, actualStr, noise, flattenKeyPath) {
     const result = [];
     const expectedJSON = JSON.parse(expectedStr);
     const actualJSON = JSON.parse(actualStr);
-    // expectedJSON and actualJSON are not of same data types
+  
+    // Type mismatch
     if (typeof expectedJSON !== typeof actualJSON) {
-        if (!noise.includes(flattenKeyPath)) {
-            result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-            result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
-            return result;
-        }
-        // console.log(expectedStr, actualStr);
-        const output = noiseDiffArray(expectedJSON, actualJSON, '');
-        output.map((el) => {
-            result.push(Object.assign(Object.assign({}, el), { noised: true }));
-        });
+      if (!noise.includes(flattenKeyPath)) {
+        result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
+        result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
         return result;
-        // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
+      }
+      const output = noiseDiffArray(expectedJSON, actualJSON, '');
+      output.map((el) => {
+        result.push({ ...el, noised: true });
+      });
+      return result;
     }
-    // expectedJSON and actualJSON are of same datatypes
+  
     switch (typeof expectedJSON) {
-        case 'string': {
-            // matches
-            if (expectedJSON === actualJSON) {
-                result.push({ count: -1, value: expectedJSON });
-                return result;
-            }
-            // not matched and ignored because its value of noise field
-            if (noise.includes(flattenKeyPath)) {
-                const output = noiseDiffArray(expectedJSON, actualJSON, '');
-                output.map((el) => {
-                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                });
-                // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-            }
-            // not matches and not noisy field's value
-            else {
-                result.push({ count: -1, removed: true, value: expectedJSON });
-                result.push({ count: -1, added: true, value: actualJSON });
-                return result;
-            }
-            break;
+      case 'string': {
+        if (expectedJSON === actualJSON) {
+          result.push({ count: -1, value: expectedJSON });
+          return result;
         }
-        case 'number': {
-            // matches
-            if (expectedJSON === actualJSON) {
-                result.push({ count: -1, value: expectedStr });
-                return result;
-            }
-            // not matched and ignored because its value of noise field
-            if (noise.includes(flattenKeyPath)) {
-                const output = noiseDiffArray(expectedJSON, actualJSON, '');
-                output.map((el) => {
-                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                });
-                // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-            }
-            // not matches and not noisy field's value
-            else {
-                result.push({ count: -1, removed: true, value: expectedStr });
-                result.push({ count: -1, added: true, value: actualStr });
-                return result;
-            }
-            break;
+        if (noise.includes(flattenKeyPath)) {
+          const output = noiseDiffArray(expectedJSON, actualJSON, '');
+          output.map((el) => {
+            result.push({ ...el, noised: true });
+          });
+        } else {
+          result.push({ count: -1, removed: true, value: expectedJSON });
+          result.push({ count: -1, added: true, value: actualJSON });
+          return result;
         }
-        case 'boolean': {
-            // matches
-            if (expectedStr === actualStr) {
-                result.push({ count: -1, value: expectedStr });
-                return result;
-            }
-            // not matched and ignored because its value of noise field
-            if (noise.includes(flattenKeyPath)) {
-                const output = noiseDiffArray(expectedJSON, actualJSON, '');
-                output.map((el) => {
-                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                });
-                // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-            }
-            // not matches and not noisy field's value
-            else {
-                result.push({ count: -1, removed: true, value: expectedStr });
-                result.push({ count: -1, added: true, value: actualStr });
-                return result;
-            }
-            break;
+        break;
+      }
+      case 'number': {
+        if (expectedJSON === actualJSON) {
+          result.push({ count: -1, value: expectedStr });
+          return result;
         }
-        case 'object': {
-            // this is the value of a noise field therefore, it should be of type default.
-            if (noise.includes(flattenKeyPath)) {
-                const output = noiseDiffArray(expectedJSON, actualJSON, '');
-                output.map((el) => {
-                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                });
-                return result;
+        if (noise.includes(flattenKeyPath)) {
+          const output = noiseDiffArray(expectedJSON, actualJSON, '');
+          output.map((el) => {
+            result.push({ ...el, noised: true });
+          });
+        } else {
+          result.push({ count: -1, removed: true, value: expectedStr });
+          result.push({ count: -1, added: true, value: actualStr });
+          return result;
+        }
+        break;
+      }
+      case 'boolean': {
+        if (expectedStr === actualStr) {
+          result.push({ count: -1, value: expectedStr });
+          return result;
+        }
+        if (noise.includes(flattenKeyPath)) {
+          const output = noiseDiffArray(expectedJSON, actualJSON, '');
+          output.map((el) => {
+            result.push({ ...el, noised: true });
+          });
+        } else {
+          result.push({ count: -1, removed: true, value: expectedStr });
+          result.push({ count: -1, added: true, value: actualStr });
+          return result;
+        }
+        break;
+      }
+      case 'object': {
+        if (noise.includes(flattenKeyPath)) {
+          const output = noiseDiffArray(expectedJSON, actualJSON, '');
+          output.map((el) => {
+            result.push({ ...el, noised: true });
+          });
+          return result;
+        }
+  
+        if (Array.isArray(expectedJSON) && Array.isArray(actualJSON)) {
+          result.push({ count: -1, value: '[' });
+  
+          expectedJSON.map((el, elIndx) => {
+            if (elIndx < actualJSON.length) {
+              const nextPath = `${flattenKeyPath}[${elIndx}]`;
+              const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, nextPath);
+              output.map((res) => {
+                res.value = `  ${res.value}`;
+                if (res.value[res.value.length - 1] != ',' && res.value.trim() !== "{" && !res.value.endsWith("_keploy_|_keploy_")) {
+                  res.value += ',';
+                }
+                result.push(res);
+              });
+            } else {
+              const lines = constructLines(JSON.stringify(el, null, 2));
+              lines.map((line) => {
+                line = `  ${line}`;
+                if (line.trim() !== "{") {
+                  line = line + ",";
+                }
+                result.push({ count: -1, removed: true, value: line });
+              });
             }
-            // when both are arrays
-            if (Array.isArray(expectedJSON) && Array.isArray(actualJSON)) {
-                result.push({ count: -1, value: '[' });
-                expectedJSON.map((el, elIndx) => {
-                    // comparing common length elements in both arrays
-                    if (elIndx < actualJSON.length) {
-                        const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, flattenKeyPath);
-                        output.map((res) => {
-                            res.value = `  ${res.value}`;
-                            if (res.count === -2) {
-                                const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                                const tagLength = '_keploy_|_keploy_'.length;
-                                res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
-                            }
-                            if (res.value[res.value.length - 1] != ',' && res.value.trim() !== "{" && !res.value.endsWith("_keploy_|_keploy_")) {
-                                res.value += ',';
-                            }
-                            result.push(res);
-                        });
+          });
+  
+          for (let indx = expectedJSON.length; indx < actualJSON.length; indx++) {
+            if (result[result.length - 1].removed) {
+              result.push({ count: -3, value: "" });
+            }
+            const lines = constructLines(JSON.stringify(actualJSON[indx], null, 2));
+            lines.map((line) => {
+              line = `  ${line}`;
+              if (line.trim() !== "{") {
+                line = line + ",";
+              }
+              result.push({ count: -1, added: true, value: line });
+            });
+          }
+          result.push({ count: -1, value: ']' });
+        } else if (
+          expectedJSON !== null &&
+          expectedJSON !== undefined &&
+          actualJSON !== null &&
+          actualJSON !== undefined &&
+          !Array.isArray(expectedJSON) &&
+          !Array.isArray(actualJSON)
+        ) {
+          result.push({ count: -1, value: '{' });
+  
+          for (const key in expectedJSON) {
+            if (key in actualJSON) {
+              const valueExpectedObj = expectedJSON[key];
+              const valueActualObj = actualJSON[key];
+              const nextPath = flattenKeyPath === "" ? `${key}` : `${flattenKeyPath}.${key}`;
+              const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
+  
+              if (valueActualObj == null && valueExpectedObj == null) {
+                result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},` });
+              } else if (
+                typeof valueExpectedObj === 'object' &&
+                (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))
+              ) {
+                if (noise.includes(nextPath)) {
+                  const nOutput = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
+                  nOutput.map((el) => {
+                    result.push({ ...el, noised: true });
+                  });
+                } else {
+                  result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
+                  result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
+                }
+              } else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
+                result.push({ count: -1, value: `  ${key}: [\n` });
+                output.map((res, resIndx) => {
+                  if (resIndx > 0) {
+                    res.value = `  ${res.value}`;
+                    if (res.count === -2) {
+                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                      const tagLength = '_keploy_|_keploy_'.length;
+                      res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
                     }
-                    // handling extra elements of expectedStr as of type removed
-                    else {
-                        const lines = constructLines(JSON.stringify(el, null, 2));
-                        lines.map((line, _lineIndex) => {
-                            line = `  ${line}`;
-                            if (line.trim() !== "{") {
-                                line = line + ",";
-                            }
-                            result.push({ count: -1, removed: true, value: line });
-                        });
-                        // result.push({count: -1, removed: true, value: JSON.stringify(el, null, 2)+","})
-                    }
+                    result.push(res);
+                  }
                 });
-                // handling extra elements of actualStr as added type
-                for (let indx = expectedJSON.length; indx < actualJSON.length; indx++) {
-                    // if last element of result is of removed type than there should be gap between added otherwise it will be considered as modification.
-                    if (result[result.length - 1].removed) {
-                        result.push({ count: -3, value: "" });
+              } else if (typeof valueExpectedObj === 'object') {
+                result.push({ count: -1, value: `  ${key}: {\n` });
+                output.map((res, resIndx) => {
+                  if (resIndx > 0) {
+                    if (res.count === -2) {
+                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                      const tagLength = '_keploy_|_keploy_'.length;
+                      res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`
+                    } else {
+                      res.value = `  ${res.value}`;
                     }
-                    const lines = constructLines(JSON.stringify(actualJSON[indx], null, 2));
-                    lines.map((line, _lineIndex) => {
-                        line = `  ${line}`;
-                        if (line.trim() !== "{") {
-                            line = line + ",";
-                        }
-                        result.push({ count: -1, added: true, value: line });
+                    result.push(res);
+                  }
+                });
+              } else {
+                if (output.length === 1) {
+                  if (output[0].count === -1) {
+                    result.push({ count: -1, value: `  ${key}: ${output[0].value},` });
+                  } else {
+                    const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
+                    const tagLength = '_keploy_|_keploy_'.length;
+                    result.push({
+                      count: -2,
+                      noised: true,
+                      value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_` + `  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},`
                     });
-                    // result.push({count: -1, added: true, value: JSON.stringify(actualJSON[indx], null, 2)+","})
+                  }
+                } else {
+                  result.push({
+                    count: output[0].count,
+                    removed: output[0].removed,
+                    added: output[0].added,
+                    value: `  ${key}: ${output[0].value},`,
+                    noised: output[0].noised
+                  });
+                  result.push({
+                    count: output[1].count,
+                    removed: output[1].removed,
+                    added: output[1].added,
+                    value: `  ${key}: ${output[1].value},`,
+                    noised: output[1].noised
+                  });
                 }
-                result.push({ count: -1, value: ']' });
+              }
+            } else {
+              result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},` });
             }
-            // both are objects and not null
-            else if (expectedJSON !== null && expectedJSON !== undefined && actualJSON !== null && actualJSON !== undefined && !Array.isArray(expectedJSON) && !Array.isArray(actualJSON)) {
-                result.push({ count: -1, value: '{' });
-                for (const key in expectedJSON) {
-                    // key present in both
-                    if (key in actualJSON) {
-                        const valueExpectedObj = expectedJSON[key];
-                        const valueActualObj = actualJSON[key];
-                        // type of value in expectedJSON for key is of same type as value in actualJSON.
-                        if (typeof valueActualObj === typeof valueExpectedObj) {
-                            var nextPath = ``;
-                            if (flattenKeyPath === "") {
-                                nextPath = `${key}`;
-                            }
-                            else {
-                                nextPath = `${flattenKeyPath}.${key}`;
-                            }
-                            const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
-                            // values of keys in expectedJSON and actualJSON are null.
-                            if (valueActualObj == null && valueExpectedObj == null) {
-                                result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},` });
-                            }
-                            // type of one is array and other is object.
-                            else if (typeof valueExpectedObj === 'object' && (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))) {
-                                // if (flattenKeyPath === "") {
-                                if (nextPath === "") {
-                                    if (noise.includes(`${key}`)) {
-                                        const output = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
-                                        output.map((el) => {
-                                            result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                                        });
-                                    }
-                                }
-                                // else if (noise.includes(`${flattenKeyPath}.${key}`)){
-                                else if (noise.includes(nextPath)) {
-                                    const output = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
-                                    output.map((el) => {
-                                        result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                                    });
-                                }
-                                else {
-                                    result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
-                                    result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
-                                }
-                            }
-                            // both values of key-value pairs are of array datatype.
-                            else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
-                                result.push({ count: -1, value: `  ${key}: [\n` });
-                                output.map((res, resIndx) => {
-                                    if (resIndx > 0) {
-                                        res.value = `  ${res.value}`;
-                                        if (res.count === -2) {
-                                            const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                                            const tagLength = '_keploy_|_keploy_'.length;
-                                            res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
-                                        }
-                                        result.push(res);
-                                    }
-                                });
-                            }
-                            // both values are objects.
-                            else if (typeof valueExpectedObj === 'object') {
-                                result.push({ count: -1, value: `  ${key}: {\n` });
-                                output.map((res, resIndx) => {
-                                    if (resIndx > 0) {
-                                        if (res.count === -2) {
-                                            const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                                            const tagLength = '_keploy_|_keploy_'.length;
-                                            res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`;
-                                        }
-                                        else {
-                                            res.value = `  ${res.value}`;
-                                        }
-                                        result.push(res);
-                                    }
-                                });
-                            }
-                            else {
-                                if (output.length === 1) {
-                                    if (output[0].count === -1) {
-                                        result.push({ count: -1, value: `  ${key}: ${output[0].value},` });
-                                    }
-                                    else {
-                                        const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
-                                        const tagLength = '_keploy_|_keploy_'.length;
-                                        result.push({ count: -2, noised: true, value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_` + `  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},` });
-                                    }
-                                }
-                                else {
-                                    result.push({
-                                        count: output[0].count,
-                                        removed: output[0].removed,
-                                        added: output[0].added,
-                                        value: `  ${key}: ${output[0].value},`,
-                                        noised: output[0].noised
-                                    });
-                                    result.push({
-                                        count: output[1].count,
-                                        removed: output[1].removed,
-                                        added: output[1].added,
-                                        value: `  ${key}: ${output[1].value},`,
-                                        noised: output[1].noised
-                                    });
-                                }
-                            }
-                        }
-                        else {
-                            if (!noise.includes(`${flattenKeyPath}.${key}`)) {
-                                result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
-                                result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
-                            }
-                            else {
-                                var output = noiseDiffArray(valueExpectedObj, valueActualObj, "  " + key + ": ");
-                                output.map(function (el) {
-                                    result.push(Object.assign(Object.assign({}, el), { noised: true }));
-                                });
-                            }
-                        }
-                    }
-                    else {
-                        result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},` });
-                    }
-                }
-                // keys not present in expectedJSON are of added type
-                for (const key in actualJSON) {
-                    // if last element of result is of removed type than there should be gap between added otherwise it will be considered as modification.
-                    if (result[result.length - 1].removed) {
-                        result.push({ count: -3, value: "" });
-                    }
-                    if (!(key in expectedJSON)) {
-                        result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},` });
-                    }
-                }
-                result.push({ count: -1, value: '}' });
+          }
+  
+          for (const key in actualJSON) {
+            if (result[result.length - 1].removed) {
+              result.push({ count: -3, value: "" })
             }
-            else if (expectedJSON == null && actualJSON == null) {
-                result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2) });
+            if (!(key in expectedJSON)) {
+              result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},` });
             }
-            else {
-                result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-                result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
-            }
-            break;
+          }
+          result.push({ count: -1, value: '}' });
+        } else if (expectedJSON == null && actualJSON == null) {
+          result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2) });
+        } else {
+          result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
+          result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
         }
+  
+        break;
+      }
     }
     return result;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,6 +29,7 @@ export interface ReactDiffViewerProps {
         additionalLineNumber: number;
         additionalPrefix: LineNumberPrefix;
         styles: ReactDiffViewerStyles;
+        flattenPath: string;
     }) => JSX.Element;
     highlightLines?: string[];
     styles?: ReactDiffViewerStylesOverride;
@@ -48,7 +49,7 @@ declare class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiff
         noise: PropTypes.Requireable<string[]>;
         splitView: PropTypes.Requireable<boolean>;
         disableWordDiff: PropTypes.Requireable<boolean>;
-        compareMethod: PropTypes.Requireable<NonNullable<((...args: any[]) => any) | DiffMethod>>;
+        compareMethod: PropTypes.Requireable<NonNullable<DiffMethod | ((...args: any[]) => any)>>;
         renderContent: PropTypes.Requireable<(...args: any[]) => any>;
         onLineNumberClick: PropTypes.Requireable<(...args: any[]) => any>;
         extraLinesSurroundingDiff: PropTypes.Requireable<number>;
@@ -61,88 +62,16 @@ declare class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiff
         linesOffset: PropTypes.Requireable<number>;
     };
     constructor(props: ReactDiffViewerProps);
-    /**
-     * Resets code block expand to the initial stage. Will be exposed to the parent component via
-     * refs.
-     */
     resetCodeBlocks: () => boolean;
-    /**
-     * Pushes the target expanded code block to the state. During the re-render,
-     * this value is used to expand/fold unmodified code.
-     */
     private onBlockExpand;
-    /**
-     * Computes final styles for the diff viewer. It combines the default styles with the user
-     * supplied overrides. The computed styles are cached with performance in mind.
-     *
-     * @param styles User supplied style overrides.
-     */
     private computeStyles;
-    /**
-     * Returns a function with clicked line number in the closure. Returns an no-op function when no
-     * onLineNumberClick handler is supplied.
-     *
-     * @param id Line id of a line.
-     */
     private onLineNumberClickProxy;
-    /**
-     * Maps over the word diff and constructs the required React elements to show word diff.
-     *
-     * @param diffArray Word diff information derived from line information.
-     * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
-     */
     private renderWordDiff;
-    /**
-     * Maps over the line diff and constructs the required react elements to show line diff. It calls
-     * renderWordDiff when encountering word diff. This takes care of both inline and split view line
-     * renders.
-     *
-     * @param lineNumber Line number of the current line.
-     * @param type Type of diff of the current line.
-     * @param prefix Unique id to prefix with the line numbers.
-     * @param value Content of the line. It can be a string or a word diff array.
-     * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
-     *  diff view. Right line number will be passed as additionalLineNumber.
-     * @param additionalPrefix Similar to prefix but for additional line number.
-     */
     private renderLine;
-    /**
-     * Generates lines for split view.
-     *
-     * @param obj Line diff information.
-     * @param obj.left Life diff information for the left pane of the split view.
-     * @param obj.right Life diff information for the right pane of the split view.
-     * @param index React key for the lines.
-     */
     private renderSplitView;
-    /**
-     * Generates lines for inline view.
-     *
-     * @param obj Line diff information.
-     * @param obj.left Life diff information for the added section of the inline view.
-     * @param obj.right Life diff information for the removed section of the inline view.
-     * @param index React key for the lines.
-     */
     renderInlineView: ({ left, right }: LineInformation, index: number) => JSX.Element;
-    /**
-     * Returns a function with clicked block number in the closure.
-     *
-     * @param id Cold fold block id.
-     */
     private onBlockClickProxy;
-    /**
-     * Generates cold fold block. It also uses the custom message renderer when available to show
-     * cold fold messages.
-     *
-     * @param num Number of skipped lines between two blocks.
-     * @param blockNumber Code fold block id.
-     * @param leftBlockLineNumber First left line number after the current code fold block.
-     * @param rightBlockLineNumber First right line number after the current code fold block.
-     */
     private renderSkippedLineIndicator;
-    /**
-     * Generates the entire diff view.
-     */
     private renderDiff;
     render: () => JSX.Element;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,10 +17,6 @@ var LineNumberPrefix;
 class DiffViewer extends React.Component {
     constructor(props) {
         super(props);
-        /**
-         * Resets code block expand to the initial stage. Will be exposed to the parent component via
-         * refs.
-         */
         this.resetCodeBlocks = () => {
             if (this.state.expandedBlocks.length > 0) {
                 this.setState({
@@ -30,10 +26,6 @@ class DiffViewer extends React.Component {
             }
             return false;
         };
-        /**
-         * Pushes the target expanded code block to the state. During the re-render,
-         * this value is used to expand/fold unmodified code.
-         */
         this.onBlockExpand = (id) => {
             const prevState = this.state.expandedBlocks.slice();
             prevState.push(id);
@@ -41,54 +33,23 @@ class DiffViewer extends React.Component {
                 expandedBlocks: prevState,
             });
         };
-        /**
-         * Computes final styles for the diff viewer. It combines the default styles with the user
-         * supplied overrides. The computed styles are cached with performance in mind.
-         *
-         * @param styles User supplied style overrides.
-         */
         this.computeStyles = memoize(styles_1.default);
-        /**
-         * Returns a function with clicked line number in the closure. Returns an no-op function when no
-         * onLineNumberClick handler is supplied.
-         *
-         * @param id Line id of a line.
-         */
         this.onLineNumberClickProxy = (id) => {
             if (this.props.onLineNumberClick) {
                 return (e) => this.props.onLineNumberClick(id, e);
             }
             return () => { };
         };
-        /**
-         * Maps over the word diff and constructs the required React elements to show word diff.
-         *
-         * @param diffArray Word diff information derived from line information.
-         * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
-         */
         this.renderWordDiff = (diffArray, renderer) => {
             return diffArray.map((wordDiff, i) => {
                 return (React.createElement("span", { key: i, className: cn(this.styles.wordDiff, {
                         [this.styles.wordAdded]: wordDiff.type === compute_lines_1.DiffType.ADDED,
                         [this.styles.wordRemoved]: wordDiff.type === compute_lines_1.DiffType.REMOVED,
                         [this.styles.wordNoised]: wordDiff.type === compute_lines_1.DiffType.NOISED,
-                    }) }, renderer ? renderer(wordDiff.value) : wordDiff.value));
+                    }), "data-flattenpath": wordDiff.flattenPath || '' }, renderer ? renderer(wordDiff.value) : wordDiff.value));
             });
         };
-        /**
-         * Maps over the line diff and constructs the required react elements to show line diff. It calls
-         * renderWordDiff when encountering word diff. This takes care of both inline and split view line
-         * renders.
-         *
-         * @param lineNumber Line number of the current line.
-         * @param type Type of diff of the current line.
-         * @param prefix Unique id to prefix with the line numbers.
-         * @param value Content of the line. It can be a string or a word diff array.
-         * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
-         *  diff view. Right line number will be passed as additionalLineNumber.
-         * @param additionalPrefix Similar to prefix but for additional line number.
-         */
-        this.renderLine = (lineNumber, type, prefix, value, additionalLineNumber, additionalPrefix) => {
+        this.renderLine = (lineNumber, type, prefix, value, flattenPath, additionalLineNumber, additionalPrefix) => {
             const lineNumberTemplate = `${prefix}-${lineNumber}`;
             const additionalLineNumberTemplate = `${additionalPrefix}-${additionalLineNumber}`;
             const highlightLine = this.props.highlightLines.includes(lineNumberTemplate) ||
@@ -113,7 +74,7 @@ class DiffViewer extends React.Component {
                         [this.styles.diffRemoved]: removed,
                         [this.styles.diffNoised]: noised,
                         [this.styles.highlightedGutter]: highlightLine,
-                    }) },
+                    }), "data-flattenpath": flattenPath || '' },
                     React.createElement("pre", { className: this.styles.lineNumber }, lineNumber))),
                 !this.props.splitView && !this.props.hideLineNumbers && (React.createElement("td", { onClick: additionalLineNumber && this.onLineNumberClickProxy(additionalLineNumberTemplate), className: cn(this.styles.gutter, {
                         [this.styles.emptyGutter]: !additionalLineNumber,
@@ -121,7 +82,7 @@ class DiffViewer extends React.Component {
                         [this.styles.diffRemoved]: removed,
                         [this.styles.diffNoised]: noised,
                         [this.styles.highlightedGutter]: highlightLine,
-                    }) },
+                    }), "data-flattenpath": flattenPath || '' },
                     React.createElement("pre", { className: this.styles.lineNumber }, additionalLineNumber))),
                 this.props.renderGutter
                     ? this.props.renderGutter({
@@ -132,6 +93,7 @@ class DiffViewer extends React.Component {
                         additionalLineNumber,
                         additionalPrefix,
                         styles: this.styles,
+                        flattenPath: flattenPath || '', // Pass flattenPath here
                     })
                     : null,
                 React.createElement("td", { className: cn(this.styles.marker, {
@@ -140,7 +102,7 @@ class DiffViewer extends React.Component {
                         [this.styles.diffRemoved]: removed,
                         [this.styles.diffNoised]: noised,
                         [this.styles.highlightedLine]: highlightLine,
-                    }) },
+                    }), "data-flattenpath": flattenPath || '' },
                     React.createElement("pre", null,
                         added && '+',
                         removed && '-')),
@@ -150,65 +112,35 @@ class DiffViewer extends React.Component {
                         [this.styles.diffRemoved]: removed,
                         [this.styles.diffNoised]: noised,
                         [this.styles.highlightedLine]: highlightLine,
-                    }) },
+                    }), "data-flattenpath": flattenPath || '' },
                     React.createElement("pre", { className: cn(this.styles.contentText, {
-                            [this.styles.wordNoised]: noised
+                            [this.styles.wordNoised]: noised,
                         }) }, content))));
         };
-        /**
-         * Generates lines for split view.
-         *
-         * @param obj Line diff information.
-         * @param obj.left Life diff information for the left pane of the split view.
-         * @param obj.right Life diff information for the right pane of the split view.
-         * @param index React key for the lines.
-         */
         this.renderSplitView = ({ left, right }, index) => {
             return (React.createElement("tr", { key: index, className: this.styles.line },
-                this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value),
-                this.renderLine(right.lineNumber, right.type, LineNumberPrefix.RIGHT, right.value)));
+                this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, left.flattenPath),
+                this.renderLine(right.lineNumber, right.type, LineNumberPrefix.RIGHT, right.value, right.flattenPath)));
         };
-        /**
-         * Generates lines for inline view.
-         *
-         * @param obj Line diff information.
-         * @param obj.left Life diff information for the added section of the inline view.
-         * @param obj.right Life diff information for the removed section of the inline view.
-         * @param index React key for the lines.
-         */
         this.renderInlineView = ({ left, right }, index) => {
-            let content;
             if (left.type === compute_lines_1.DiffType.REMOVED && right.type === compute_lines_1.DiffType.ADDED) {
                 return (React.createElement(React.Fragment, { key: index },
-                    React.createElement("tr", { className: this.styles.line }, this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, null)),
-                    React.createElement("tr", { className: this.styles.line }, this.renderLine(null, right.type, LineNumberPrefix.RIGHT, right.value, right.lineNumber))));
+                    React.createElement("tr", { className: this.styles.line }, this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, left.flattenPath)),
+                    React.createElement("tr", { className: this.styles.line }, this.renderLine(null, right.type, LineNumberPrefix.RIGHT, right.value, right.flattenPath, right.lineNumber))));
             }
+            let content;
             if (left.type === compute_lines_1.DiffType.REMOVED) {
-                content = this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, null);
+                content = this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, left.flattenPath, null);
             }
             if (left.type === compute_lines_1.DiffType.DEFAULT) {
-                content = this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, right.lineNumber, LineNumberPrefix.RIGHT);
+                content = this.renderLine(left.lineNumber, left.type, LineNumberPrefix.LEFT, left.value, left.flattenPath, right.lineNumber, LineNumberPrefix.RIGHT);
             }
             if (right.type === compute_lines_1.DiffType.ADDED) {
-                content = this.renderLine(null, right.type, LineNumberPrefix.RIGHT, right.value, right.lineNumber);
+                content = this.renderLine(null, right.type, LineNumberPrefix.RIGHT, right.value, right.flattenPath, right.lineNumber);
             }
             return (React.createElement("tr", { key: index, className: this.styles.line }, content));
         };
-        /**
-         * Returns a function with clicked block number in the closure.
-         *
-         * @param id Cold fold block id.
-         */
         this.onBlockClickProxy = (id) => () => this.onBlockExpand(id);
-        /**
-         * Generates cold fold block. It also uses the custom message renderer when available to show
-         * cold fold messages.
-         *
-         * @param num Number of skipped lines between two blocks.
-         * @param blockNumber Code fold block id.
-         * @param leftBlockLineNumber First left line number after the current code fold block.
-         * @param rightBlockLineNumber First right line number after the current code fold block.
-         */
         this.renderSkippedLineIndicator = (num, blockNumber, leftBlockLineNumber, rightBlockLineNumber) => {
             const { hideLineNumbers, splitView } = this.props;
             const message = this.props.codeFoldMessageRenderer ? (this.props.codeFoldMessageRenderer(num, leftBlockLineNumber, rightBlockLineNumber)) : (React.createElement("pre", { className: this.styles.codeFoldContent },
@@ -220,7 +152,7 @@ class DiffViewer extends React.Component {
             const isUnifiedViewWithoutLineNumbers = !splitView && !hideLineNumbers;
             return (React.createElement("tr", { key: `${leftBlockLineNumber}-${rightBlockLineNumber}`, className: this.styles.codeFold },
                 !hideLineNumbers && React.createElement("td", { className: this.styles.codeFoldGutter }),
-                this.props.renderGutter ? (React.createElement("td", { className: this.styles.codeFoldGutter })) : null,
+                this.props.renderGutter ? React.createElement("td", { className: this.styles.codeFoldGutter }) : null,
                 React.createElement("td", { className: cn({
                         [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
                     }) }),
@@ -231,18 +163,12 @@ class DiffViewer extends React.Component {
                     this.props.renderGutter ? React.createElement("td", null) : null,
                     React.createElement("td", null))),
                 React.createElement("td", null),
-                React.createElement("td", null),
-                "ReactDiffView"));
+                React.createElement("td", null)));
         };
-        /**
-         * Generates the entire diff view.
-         */
         this.renderDiff = () => {
             const { oldValue, newValue, noise, splitView, disableWordDiff, compareMethod, linesOffset, } = this.props;
             const { lineInformation, diffLines } = (0, compute_lines_1.computeLineInformation)(oldValue, newValue, noise, disableWordDiff, compareMethod, linesOffset);
-            const extraLines = this.props.extraLinesSurroundingDiff < 0
-                ? 0
-                : this.props.extraLinesSurroundingDiff;
+            const extraLines = this.props.extraLinesSurroundingDiff < 0 ? 0 : this.props.extraLinesSurroundingDiff;
             let skippedLines = [];
             return lineInformation.map((line, i) => {
                 const diffBlockStart = diffLines[0];
@@ -253,8 +179,7 @@ class DiffViewer extends React.Component {
                         diffLines.shift();
                     }
                     if (line.left.type === compute_lines_1.DiffType.DEFAULT &&
-                        (currentPosition > extraLines ||
-                            typeof diffBlockStart === 'undefined') &&
+                        (currentPosition > extraLines || typeof diffBlockStart === 'undefined') &&
                         !this.state.expandedBlocks.includes(diffBlockStart)) {
                         skippedLines.push(i + 1);
                         if (i === lineInformation.length - 1 && skippedLines.length > 1) {
@@ -287,8 +212,7 @@ class DiffViewer extends React.Component {
             const colSpanOnInlineView = hideLineNumbers ? 2 : 4;
             let columnExtension = this.props.renderGutter ? 1 : 0;
             const title = (leftTitle || rightTitle) && (React.createElement("tr", null,
-                React.createElement("td", { colSpan: (splitView ? colSpanOnSplitView : colSpanOnInlineView) +
-                        columnExtension, className: this.styles.titleBlock },
+                React.createElement("td", { colSpan: (splitView ? colSpanOnSplitView : colSpanOnInlineView) + columnExtension, className: this.styles.titleBlock },
                     React.createElement("pre", { className: this.styles.contentText }, leftTitle)),
                 splitView && (React.createElement("td", { colSpan: colSpanOnSplitView + columnExtension, className: this.styles.titleBlock },
                     React.createElement("pre", { className: this.styles.contentText }, rightTitle)))));

--- a/src/compute-lines.ts
+++ b/src/compute-lines.ts
@@ -16,7 +16,6 @@
 /* eslint-disable max-len */
 // keploy-react-diff
 import * as diff from 'diff';
-import { string } from 'prop-types';
 
 const jsDiff: { [key: string]: any } = diff;
 
@@ -42,6 +41,7 @@ export interface DiffInformation {
   value?: string | DiffInformation[];
   lineNumber?: number;
   type?: DiffType;
+  flattenPath?: string;
 }
 
 export interface LineInformation {
@@ -53,8 +53,10 @@ export interface ComputedLineInformation {
   lineInformation: LineInformation[];
   diffLines: number[];
 }
+
 interface DiffChange extends diff.Change {
-  noised?: boolean
+  noised?: boolean;
+  flattenPath?: string;
 }
 
 export interface ComputedDiffInformation {
@@ -68,12 +70,12 @@ export interface JsDiffChangeObject {
   added?: boolean;
   removed?: boolean;
   value?: string;
-  noised?: boolean
+  noised?: boolean;
+  flattenPath?: string;
 }
 
 /**
- * Splits diff text by new line and computes final list of diff lines based on
- * conditions.
+ * Splits diff text by new line and computes final list of diff lines based on conditions.
  *
  * @param value Diff text from the js diff module.
  */
@@ -81,14 +83,13 @@ const constructLines = (value: string): string[] => {
   if (value === undefined) {
     return [];
   }
-  value = value.replace(/\n,/gi, "\n")
+  value = value.replace(/\n,/gi, "\n");
   if (value.trim() === ",") {
-    value = ""
+    value = "";
   }
   const lines = value.split('\n');
   const isAllEmpty = lines.every((val): boolean => !val);
   if (isAllEmpty) {
-    // This is to avoid added an extra new line in the UI.
     if (lines.length === 2) {
       return [];
     }
@@ -155,51 +156,43 @@ const computeDiff = (
   return computedDiff;
 };
 
-function noiseDiffArray(expectedObj: any, actualObj: any, key: string): DiffChange[] {
+const sanitizeInput = (input: string): string => {
+  return input.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\/g, '');
+};
+
+function noiseDiffArray(expectedObj: any, actualObj: any, key: string, flattenKeyPath: string = ''): DiffChange[] {
   const result: DiffChange[] = [];
   const expectedLines = constructLines(JSON.stringify(expectedObj, null, 2));
   const actualLines = constructLines(JSON.stringify(actualObj, null, 2));
-  expectedLines.map((el, elIndex) => {
+  expectedLines.forEach((el, elIndex) => {
     // to handle common length of both lines array.
     if (elIndex < actualLines.length) {
       // add key only to the first line before and after seperator.
       if (elIndex === 0) {
-        actualLines[elIndex] = sanitizeInput(actualLines[elIndex])
-        el = sanitizeInput(el)
-        result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}${actualLines[elIndex]}` });
+        actualLines[elIndex] = sanitizeInput(actualLines[elIndex]);
+        el = sanitizeInput(el);
+        result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}${actualLines[elIndex]}`, flattenPath: flattenKeyPath });
       }
       else {
-        actualLines[elIndex] = sanitizeInput(actualLines[elIndex])
-        el = sanitizeInput(el)
-        result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_  ${actualLines[elIndex]}` })
+        actualLines[elIndex] = sanitizeInput(actualLines[elIndex]);
+        el = sanitizeInput(el);
+        result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_  ${actualLines[elIndex]}`, flattenPath: flattenKeyPath });
       }
-
+    } else if (elIndex === 0) {
+      el = sanitizeInput(el);
+      result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}`, flattenPath: flattenKeyPath });
+    } else {
+      el = sanitizeInput(el);
+      result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_`, flattenPath: flattenKeyPath });
     }
-    // lines in expectedObj is greater than actualObj and add key string only to the first line.
-    // example: expectedObj: "", actualObj: "[1, 2, true]"
-    else if (elIndex === 0) {
-      el = sanitizeInput(el)
-      result.push({ count: -2, noised: true, value: `${key + el}_keploy_|_keploy_${key}` });
-    }
-    else {
-      el = sanitizeInput(el)
-      result.push({ count: -2, noised: true, value: `  ${el}_keploy_|_keploy_` });
-    }
-
   });
   for (let indx = expectedLines.length; indx < actualLines.length; indx++) {
-    // lines in actual object is greater than expected object.
-    // example: expectedObj: "[1, 2, true]", actualObj: ""
-
     if (indx === 0) {
-      actualLines[indx] = sanitizeInput(actualLines[indx])
-      // expectedLines[indx] = sanitizeInput(expectedLines[indx])
-      result.push({ count: -2, noised: true, value: `${key}_keploy_|_keploy_${key}${actualLines[indx]}` });
-    }
-    else {
-      actualLines[indx] = sanitizeInput(actualLines[indx])
-      // expectedLines[indx] = sanitizeInput(expectedLines[indx])
-      result.push({ count: -2, noised: true, value: `_keploy_|_keploy_  ${actualLines[indx]}` });
+      actualLines[indx] = sanitizeInput(actualLines[indx]);
+      result.push({ count: -2, noised: true, value: `${key}_keploy_|_keploy_${key}${actualLines[indx]}`, flattenPath: flattenKeyPath });
+    } else {
+      actualLines[indx] = sanitizeInput(actualLines[indx]);
+      result.push({ count: -2, noised: true, value: `_keploy_|_keploy_  ${actualLines[indx]}`, flattenPath: flattenKeyPath });
     }
   }
   return result;
@@ -210,310 +203,244 @@ function CompareJSON(expectedStr: string, actualStr: string, noise: string[], fl
   const expectedJSON = JSON.parse(expectedStr);
   const actualJSON = JSON.parse(actualStr);
 
-  // expectedJSON and actualJSON are not of same data types
+  // Type mismatch
   if (typeof expectedJSON !== typeof actualJSON) {
     if (!noise.includes(flattenKeyPath)) {
-      result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-      result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
+      result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
+      result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2), flattenPath: flattenKeyPath });
       return result;
     }
-
-    // console.log(expectedStr, actualStr);
-    const output = noiseDiffArray(expectedJSON, actualJSON, '');
-    output.map((el) => {
+    const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+    output.forEach((el) => {
       result.push({ ...el, noised: true });
     });
-
-    return result
-    // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
+    return result;
   }
 
-  // expectedJSON and actualJSON are of same datatypes
   switch (typeof expectedJSON) {
     case 'string': {
-      // matches
       if (expectedJSON === actualJSON) {
-        result.push({ count: -1, value: expectedJSON });
+        result.push({ count: -1, value: expectedJSON, flattenPath: flattenKeyPath });
         return result;
       }
-      // not matched and ignored because its value of noise field
       if (noise.includes(flattenKeyPath)) {
-        const output = noiseDiffArray(expectedJSON, actualJSON, '');
-        output.map((el) => {
+        const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+        output.forEach((el) => {
           result.push({ ...el, noised: true });
         });
-        // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-      }
-      // not matches and not noisy field's value
-      else {
-        result.push({ count: -1, removed: true, value: expectedJSON });
-        result.push({ count: -1, added: true, value: actualJSON });
+      } else {
+        result.push({ count: -1, removed: true, value: expectedJSON, flattenPath: flattenKeyPath });
+        result.push({ count: -1, added: true, value: actualJSON, flattenPath: flattenKeyPath });
         return result;
       }
       break;
     }
     case 'number': {
-      // matches
       if (expectedJSON === actualJSON) {
-        result.push({ count: -1, value: expectedStr });
+        result.push({ count: -1, value: expectedStr, flattenPath: flattenKeyPath });
         return result;
       }
-      // not matched and ignored because its value of noise field
       if (noise.includes(flattenKeyPath)) {
-        const output = noiseDiffArray(expectedJSON, actualJSON, '');
-
-        output.map((el) => {
+        const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+        output.forEach((el) => {
           result.push({ ...el, noised: true });
         });
-        // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-      }
-      // not matches and not noisy field's value
-      else {
-        result.push({ count: -1, removed: true, value: expectedStr });
-        result.push({ count: -1, added: true, value: actualStr });
+      } else {
+        result.push({ count: -1, removed: true, value: expectedStr, flattenPath: flattenKeyPath });
+        result.push({ count: -1, added: true, value: actualStr, flattenPath: flattenKeyPath });
         return result;
       }
       break;
     }
     case 'boolean': {
-      // matches
       if (expectedStr === actualStr) {
-        result.push({ count: -1, value: expectedStr });
+        result.push({ count: -1, value: expectedStr, flattenPath: flattenKeyPath });
         return result;
       }
-      // not matched and ignored because its value of noise field
       if (noise.includes(flattenKeyPath)) {
-        const output = noiseDiffArray(expectedJSON, actualJSON, '');
-        output.map((el) => {
+        const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+        output.forEach((el) => {
           result.push({ ...el, noised: true });
         });
-        // result.push({count: -2, value: expectedStr+"_keploy_|_keploy_"+actualStr})
-      }
-      // not matches and not noisy field's value
-      else {
-        result.push({ count: -1, removed: true, value: expectedStr });
-        result.push({ count: -1, added: true, value: actualStr });
+      } else {
+        result.push({ count: -1, removed: true, value: expectedStr, flattenPath: flattenKeyPath });
+        result.push({ count: -1, added: true, value: actualStr, flattenPath: flattenKeyPath });
         return result;
       }
       break;
     }
     case 'object': {
-      // this is the value of a noise field therefore, it should be of type default.
       if (noise.includes(flattenKeyPath)) {
-        const output = noiseDiffArray(expectedJSON, actualJSON, '');
-        output.map((el) => {
+        const output = noiseDiffArray(expectedJSON, actualJSON, '', flattenKeyPath);
+        output.forEach((el) => {
           result.push({ ...el, noised: true });
         });
         return result;
       }
-      // when both are arrays
+
+      // Both arrays
       if (Array.isArray(expectedJSON) && Array.isArray(actualJSON)) {
-        result.push({ count: -1, value: '[' });
+        result.push({ count: -1, value: '[', flattenPath: flattenKeyPath });
 
-        expectedJSON.map((el, elIndx) => {
-
-          // comparing common length elements in both arrays
+        expectedJSON.forEach((el: any, elIndx: number) => {
+          const elementPath = flattenKeyPath === "" ? `[${elIndx}]` : `${flattenKeyPath}[${elIndx}]`;
           if (elIndx < actualJSON.length) {
-            const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, flattenKeyPath);
-            output.map((res) => {
+            const output = CompareJSON(JSON.stringify(el, null, 2), JSON.stringify(actualJSON[elIndx], null, 2), noise, elementPath);
+            output.forEach((res) => {
               res.value = `  ${res.value}`;
-              if (res.count === -2) {
-                const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                const tagLength = '_keploy_|_keploy_'.length;
-                res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
-              }
-
-              if (res.value[res.value.length - 1] != ',' && res.value.trim() !== "{" && !res.value.endsWith("_keploy_|_keploy_")) {
+              if (
+                res.value[res.value.length - 1] !== ',' &&
+                res.value.trim() !== "{" &&
+                !res.value.endsWith("_keploy_|_keploy_")
+              ) {
                 res.value += ',';
               }
+              // ensure each element line has correct flattenPath
+              res.flattenPath = res.flattenPath || elementPath;
               result.push(res);
             });
-          }
-          // handling extra elements of expectedStr as of type removed
-          else {
+          } else {
             const lines = constructLines(JSON.stringify(el, null, 2));
-            lines.map((line, _lineIndex) => {
-              line = `  ${line}`;
-              if (line.trim() !== "{") {
-                line = line + ","
+            lines.forEach((line) => {
+              let modifiedLine = `  ${line}`;
+              if (modifiedLine.trim() !== "{") {
+                modifiedLine = modifiedLine + ",";
               }
-              result.push({ count: -1, removed: true, value: line });
+              result.push({ count: -1, removed: true, value: modifiedLine, flattenPath: elementPath });
             });
-            // result.push({count: -1, removed: true, value: JSON.stringify(el, null, 2)+","})
           }
-
         });
 
-        // handling extra elements of actualStr as added type
         for (let indx = expectedJSON.length; indx < actualJSON.length; indx++) {
-          // if last element of result is of removed type than there should be gap between added otherwise it will be considered as modification.
           if (result[result.length - 1].removed) {
-            result.push({ count: -3, value: "" })
+            result.push({ count: -3, value: "", flattenPath: flattenKeyPath });
           }
-
+          const elementPath = flattenKeyPath === "" ? `[${indx}]` : `${flattenKeyPath}[${indx}]`;
           const lines = constructLines(JSON.stringify(actualJSON[indx], null, 2));
-          lines.map((line, _lineIndex) => {
-            line = `  ${line}`;
-            if (line.trim() !== "{") {
-              line = line + ","
+          lines.forEach((line) => {
+            let modifiedLine = `  ${line}`;
+            if (modifiedLine.trim() !== "{") {
+              modifiedLine = modifiedLine + ",";
             }
-            result.push({ count: -1, added: true, value: line });
+            result.push({ count: -1, added: true, value: modifiedLine, flattenPath: elementPath });
           });
-          // result.push({count: -1, added: true, value: JSON.stringify(actualJSON[indx], null, 2)+","})
         }
 
-        result.push({ count: -1, value: ']' });
+        result.push({ count: -1, value: ']', flattenPath: flattenKeyPath });
       }
-      // both are objects and not null
-      else if (expectedJSON !== null && expectedJSON !== undefined && actualJSON !== null && actualJSON !== undefined && !Array.isArray(expectedJSON) && !Array.isArray(actualJSON)) {
-        result.push({ count: -1, value: '{' });
+      // Both objects
+      else if (
+        expectedJSON !== null && expectedJSON !== undefined &&
+        actualJSON !== null && actualJSON !== undefined &&
+        !Array.isArray(expectedJSON) && !Array.isArray(actualJSON)
+      ) {
+        result.push({ count: -1, value: '{', flattenPath: flattenKeyPath });
 
         for (const key in expectedJSON) {
-
-          // key present in both
+          const nextPath = flattenKeyPath === "" ? `${key}` : `${flattenKeyPath}.${key}`;
           if (key in actualJSON) {
             const valueExpectedObj = expectedJSON[key];
             const valueActualObj = actualJSON[key];
-            // type of value in expectedJSON for key is of same type as value in actualJSON.
-            if (typeof valueActualObj === typeof valueExpectedObj) {
-              var nextPath: string = ``;
-              if (flattenKeyPath === "") {
-                nextPath = `${key}`;
-              } else {
-                nextPath = `${flattenKeyPath}.${key}`;
-              }
-              const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
+            const output = CompareJSON(JSON.stringify(valueExpectedObj, null, 2), JSON.stringify(valueActualObj, null, 2), noise, nextPath);
 
-              // values of keys in expectedJSON and actualJSON are null.
-              if (valueActualObj == null && valueExpectedObj == null) {
-                result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},` });
-              }
-              // type of one is array and other is object.
-              else if (typeof valueExpectedObj === 'object' && (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))) {
-                // if (flattenKeyPath === "") {
-                if (nextPath === "") {
-                  if (noise.includes(`${key}`)) {
-                    const output = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
-                    output.map((el) => {
-                      result.push({ ...el, noised: true });
-                    });
-                  }
-                }
-                // else if (noise.includes(`${flattenKeyPath}.${key}`)){
-                else if (noise.includes(nextPath)) {
-                  const output = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `);
-                  output.map((el) => {
-                    result.push({ ...el, noised: true });
-                  });
-                }
-                else {
-                  result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
-                  result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
-                }
-              }
-              // both values of key-value pairs are of array datatype.
-              else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
-                result.push({ count: -1, value: `  ${key}: [\n` });
-
-                output.map((res, resIndx) => {
-                  if (resIndx > 0) {
-                    res.value = `  ${res.value}`;
-                    if (res.count === -2) {
-                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                      const tagLength = '_keploy_|_keploy_'.length;
-                      res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
-                    }
-                    result.push(res);
-                  }
-                });
-
-              }
-              // both values are objects.
-              else if (typeof valueExpectedObj === 'object') {
-                result.push({ count: -1, value: `  ${key}: {\n` });
-
-                output.map((res, resIndx) => {
-                  if (resIndx > 0) {
-
-                    if (res.count === -2) {
-                      const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
-                      const tagLength = '_keploy_|_keploy_'.length;
-                      res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`
-                    }
-                    else {
-                      res.value = `  ${res.value}`;
-                    }
-
-                    result.push(res);
-                  }
-                });
-
-              } else {
-
-                if (output.length === 1) {
-
-                  if (output[0].count === -1) {
-                    result.push({ count: -1, value: `  ${key}: ${output[0].value},` });
-                  } else {
-                    const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
-                    const tagLength = '_keploy_|_keploy_'.length;
-                    result.push({ count: -2, noised: true, value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_` + `  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},` });
-                  }
-
-                }
-                else {
-                  result.push({
-                    count: output[0].count,
-                    removed: output[0].removed,
-                    added: output[0].added,
-                    value: `  ${key}: ${output[0].value},`,
-                    noised: output[0].noised
-                  });
-                  result.push({
-                    count: output[1].count,
-                    removed: output[1].removed,
-                    added: output[1].added,
-                    value: `  ${key}: ${output[1].value},`,
-                    noised: output[1].noised
-                  });
-                }
-
-              }
-            } else {
-
-              if (!noise.includes(`${flattenKeyPath}.${key}`)) {
-                result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},` });
-                result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},` });
-              } else {
-                var output = noiseDiffArray(valueExpectedObj, valueActualObj, "  " + key + ": ");
-                output.map(function (el) {
+            if (valueActualObj == null && valueExpectedObj == null) {
+              result.push({ count: -1, value: `  ${key}: ${JSON.stringify(null)},`, flattenPath: nextPath });
+            } else if (typeof valueExpectedObj === 'object' && (Array.isArray(valueExpectedObj) ? !Array.isArray(valueActualObj) : Array.isArray(valueActualObj))) {
+              if (noise.includes(nextPath)) {
+                const nOutput = noiseDiffArray(valueExpectedObj, valueActualObj, `  ${key}: `, nextPath);
+                nOutput.forEach((el) => {
                   result.push({ ...el, noised: true });
                 });
+              } else {
+                result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(valueExpectedObj, null, 2)},`, flattenPath: nextPath });
+                result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(valueActualObj, null, 2)},`, flattenPath: nextPath });
               }
+            } else if (typeof valueExpectedObj === 'object' && Array.isArray(valueExpectedObj)) {
+              result.push({ count: -1, value: `  ${key}: [\n`, flattenPath: nextPath });
 
+              output.forEach((res, resIndx) => {
+                if (resIndx > 0) {
+                  res.value = `  ${res.value}`;
+                  if (res.count === -2) {
+                    const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                    const tagLength = '_keploy_|_keploy_'.length;
+                    res.value = res.value.substring(0, tagStartIndex) + "_keploy_|_keploy_  " + res.value.substring(tagStartIndex + tagLength);
+                  }
+                  res.flattenPath = res.flattenPath || nextPath;
+                  result.push(res);
+                }
+              });
+
+            } else if (typeof valueExpectedObj === 'object') {
+              result.push({ count: -1, value: `  ${key}: {\n`, flattenPath: nextPath });
+
+              output.forEach((res, resIndx) => {
+                if (resIndx > 0) {
+                  if (res.count === -2) {
+                    const tagStartIndex = res.value.indexOf('_keploy_|_keploy_');
+                    const tagLength = '_keploy_|_keploy_'.length;
+                    res.value = `  ${res.value.substring(0, tagStartIndex)}_keploy_|_keploy_  ${res.value.substring(tagStartIndex + tagLength)}`;
+                  } else {
+                    res.value = `  ${res.value}`;
+                  }
+                  res.flattenPath = res.flattenPath || nextPath;
+                  result.push(res);
+                }
+              });
+
+            } else {
+              // primitive values
+              if (output.length === 1) {
+                if (output[0].count === -1) {
+                  result.push({ count: -1, value: `  ${key}: ${output[0].value},`, flattenPath: nextPath });
+                } else {
+                  const tagStartIndex = output[0].value.indexOf('_keploy_|_keploy_');
+                  const tagLength = '_keploy_|_keploy_'.length;
+                  result.push({
+                    count: -2,
+                    noised: true,
+                    value: `  ${key}: ${output[0].value.substring(0, tagStartIndex)},_keploy_|_keploy_  ${key}: ${output[0].value.substring(tagStartIndex + tagLength)},`,
+                    flattenPath: nextPath
+                  });
+                }
+              } else {
+                result.push({
+                  count: output[0].count,
+                  removed: output[0].removed,
+                  added: output[0].added,
+                  value: `  ${key}: ${output[0].value},`,
+                  noised: output[0].noised,
+                  flattenPath: nextPath
+                });
+                result.push({
+                  count: output[1].count,
+                  removed: output[1].removed,
+                  added: output[1].added,
+                  value: `  ${key}: ${output[1].value},`,
+                  noised: output[1].noised,
+                  flattenPath: nextPath
+                });
+              }
             }
           } else {
-            result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},` });
+            // key missing in actual
+            result.push({ count: -1, removed: true, value: `  ${key}: ${JSON.stringify(expectedJSON[key], null, 2)},`, flattenPath: flattenKeyPath });
           }
         }
-        // keys not present in expectedJSON are of added type
         for (const key in actualJSON) {
-          // if last element of result is of removed type than there should be gap between added otherwise it will be considered as modification.
           if (result[result.length - 1].removed) {
-            result.push({ count: -3, value: "" })
+            result.push({ count: -3, value: "", flattenPath: flattenKeyPath });
           }
           if (!(key in expectedJSON)) {
-            result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},` });
+            result.push({ count: -1, added: true, value: `  ${key}: ${JSON.stringify(actualJSON[key], null, 2)},`, flattenPath: flattenKeyPath });
           }
         }
-        result.push({ count: -1, value: '}' });
-      }
-      else if (expectedJSON == null && actualJSON == null) {
-        result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2) });
-      }
-      else {
-        result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2) });
-        result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2) });
+        result.push({ count: -1, value: '}', flattenPath: flattenKeyPath });
+      } else if (expectedJSON == null && actualJSON == null) {
+        result.push({ count: -1, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
+      } else {
+        result.push({ count: -1, removed: true, value: JSON.stringify(expectedJSON, null, 2), flattenPath: flattenKeyPath });
+        result.push({ count: -1, added: true, value: JSON.stringify(actualJSON, null, 2), flattenPath: flattenKeyPath });
       }
 
       break;
@@ -523,24 +450,17 @@ function CompareJSON(expectedStr: string, actualStr: string, noise: string[], fl
 }
 
 /**
- * [TODO]: Think about moving common left and right value assignment to a
- * common place. Better readability?
- *
- * Computes line wise information based in the js diff information passed. Each
- * line contains information about left and right section. Left side denotes
- * deletion and right side denotes addition.
+ * Computes line-wise diff information from two input strings. If JSON, uses CompareJSON,
+ * otherwise uses a simple line diff. Also incorporates flattenPath from CompareJSON results.
  *
  * @param oldString Old string to compare.
  * @param newString New string to compare with old string.
+ * @param noise Noise array for ignoring certain paths.
  * @param disableWordDiff Flag to enable/disable word diff.
- * @param compareMethod JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
- * @param linesOffset line number to start counting from
+ * @param compareMethod JsDiff method.
+ * @param linesOffset Starting line number offset.
  */
-const sanitizeInput = (input: string): string => {
-  return input.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\/g, '');
-};
-
-const computeLineInformation = (
+export const computeLineInformation = (
   oldString: string,
   newString: string,
   noise: string[],
@@ -549,55 +469,21 @@ const computeLineInformation = (
   linesOffset: number = 0,
 ): ComputedLineInformation => {
 
-  // oldString = sanitizeInput(oldString);
-  // newString = sanitizeInput(newString);
-
-  // let noiseTmp:string[] = []
-  // for(let i=0; i<noise.length ;i++){
-  // 	noiseTmp.push(noise[i])
-  // }
-  // let expectedStr =  addNoiseTags(oldString, "keploy.noise.l", noiseTmp, false)[0] as string
-  // let actualStr = addNoiseTags(newString, "keploy.noise.r", noise, false)[0]  as string
-
-  let diffArray: DiffChange[]
-  var validJSON: string = "plain"
   if (noise === null || noise === undefined) {
-    noise = []
+    noise = [];
   }
+
+  let diffArray: DiffChange[];
+  let validJSON: string = "plain";
   try {
-    JSON.parse(oldString)
-    JSON.parse(newString)
-    // if (noise === null || noise === undefined){
-    //   noise = []
-    // }
-    // diffArray = CompareJSON(
-    //   oldString.trimRight(),
-    //   newString.trimRight(),
-    //   noise,
-    //   "body",
-    // )
-    validJSON = "JSON"
+    JSON.parse(oldString);
+    JSON.parse(newString);
+    validJSON = "JSON";
   }
   catch (e) {
-    // if ( noise==null || noise.length==0 || (noise.length>0 && !noise.includes("body"))){
-    //   diffArray = diff.diffLines(
-    //     oldString.trimRight(),
-    //     newString.trimRight(),
-    //     {
-    //       newlineIsToken: true,
-    //       ignoreWhitespace: false,
-    //       ignoreCase: false,
-    //     },
-    //   )
-    //   if (diffArray.length ===1 ){
-    //     diffArray[0].count = -1
-    //   }
-    // }
-    // else{
-    //   diffArray = noiseDiffArray(oldString, newString, "")
-    // }
-
+    // fall back to plain text diff if not valid JSON
   }
+
   if (validJSON === 'plain') {
     if (noise == null || noise.length == 0 || (noise.length > 0 && !noise.includes("body"))) {
       diffArray = diff.diffLines(
@@ -608,85 +494,55 @@ const computeLineInformation = (
           ignoreWhitespace: false,
           ignoreCase: false,
         },
-      )
+      ) as DiffChange[];
       if (diffArray.length === 1) {
-        diffArray[0].count = -1
+        diffArray[0].count = -1;
       }
+      diffArray.forEach(d => {
+        if (d.flattenPath === undefined) {
+          d.flattenPath = "";
+        }
+      });
+    } else {
+      diffArray = noiseDiffArray(oldString, newString, "", "");
     }
-    else {
-      diffArray = noiseDiffArray(oldString, newString, "")
-    }
-  }
-  else {
+  } else {
     diffArray = CompareJSON(
       oldString.trimRight(),
       newString.trimRight(),
       noise,
       "",
-    )
+    );
   }
 
-  // const diffArray = CompareJSON(
-  // 	 oldString.trimRight(),
-  // 	 newString.trimRight(),
-  // 	 noise,
-  // 	 'body',
-  //   // {
-  //   // 	newlineIsToken: true,
-  //   // 	ignoreWhitespace: false,
-  //   // 	ignoreCase: false,
-  //   // },
-  // );
-  // [
-  // 	{
-  // 		added: Boolean,
-  // 		removed: Boolean,
-  // 		count: 1234,
-  // 		value: "{ "name": "ritik,"\n "age ": 21"
-  // 	},
-  // 	{
-  // 		removed: true,
-  // 		count: 1,
-  // 		value: "contact: "keploy.noise.l78278782892", \n"
-  // 	},
-  // 	{
-  // 		added: true,
-  // 		count: 1,
-  // 		value: "contact: "keploy.noise.r7827212052", \n"
-  // 	},
-  // ]
-  // console.log(diffArray);
-  // diffArray.forEach((element, elIndex) => {
-  // 	if (element.value.includes("keploy.noise")){
-  // 		element.added = undefined
-  // 		element.removed = undefined
-  // 	}
-  // });
-  // console.log(noise);
   let rightLineNumber = linesOffset;
   let leftLineNumber = linesOffset;
   let lineInformation: LineInformation[] = [];
   let counter = 0;
   const diffLines: number[] = [];
   const ignoreDiffIndexes: string[] = [];
+
   const getLineInformation = (
     value: string,
     diffIndex: number,
     added?: boolean,
     removed?: boolean,
-    noised?: boolean, // Add noised parameter
+    noised?: boolean,
     evaluateOnlyFirstLine?: boolean,
     LineIndexTobeReturned?: number,
   ): LineInformation[] => {
     const lines = constructLines(value);
     return lines.map((line: string, lineIndex): LineInformation => {
-      const left: DiffInformation = {};
-      const right: DiffInformation = {};
       if (ignoreDiffIndexes.includes(`${diffIndex}-${lineIndex}`)
         || (evaluateOnlyFirstLine && lineIndex !== 0) || diffArray[diffIndex].count === -3) {
         return undefined;
       }
-      if (added || removed) { // Include noised in the condition
+
+      const left: DiffInformation = {};
+      const right: DiffInformation = {};
+      const currentFlattenPath = diffArray[diffIndex].flattenPath || "";
+
+      if (added || removed) {
         if (!diffLines.includes(counter)) {
           diffLines.push(counter);
         }
@@ -695,6 +551,7 @@ const computeLineInformation = (
           left.lineNumber = leftLineNumber;
           left.type = DiffType.REMOVED;
           left.value = line || ' ';
+          left.flattenPath = currentFlattenPath;
           const nextDiff = diffArray[diffIndex + 1];
           if (nextDiff && nextDiff.added) {
             const nextDiffLines = constructLines(nextDiff.value)[lineIndex];
@@ -702,30 +559,32 @@ const computeLineInformation = (
               lines.push(' ');
             }
             if (nextDiffLines) {
-              const {
-                value: rightValue,
-                lineNumber,
-                type,
-              } = getLineInformation(
+              const nextLineInfo = getLineInformation(
                 nextDiff.value,
-                diffIndex,
+                diffIndex + 1,
                 true,
                 false,
-                nextDiff.noised // Pass noised
-              )[lineIndex].right;
-              ignoreDiffIndexes.push(`${diffIndex + 1}-${lineIndex}`);
-              right.lineNumber = lineNumber;
-              right.type = type;
-              if (disableWordDiff) {
-                right.value = rightValue;
-              } else {
-                const computedDiff = computeDiff(
-                  line,
-                  rightValue as string,
-                  compareMethod,
-                );
-                right.value = computedDiff.right;
-                left.value = computedDiff.left;
+                nextDiff.noised
+              );
+              const nextInfo = nextLineInfo[lineIndex];
+              if (nextInfo && nextInfo.right) {
+                ignoreDiffIndexes.push(`${diffIndex + 1}-${lineIndex}`);
+                right.lineNumber = nextInfo.right.lineNumber;
+                right.type = nextInfo.right.type;
+                right.flattenPath = nextDiff.flattenPath || "";
+                if (disableWordDiff) {
+                  right.value = nextInfo.right.value;
+                } else {
+                  const computedDiff = computeDiff(
+                    line,
+                    nextInfo.right.value as string,
+                    compareMethod,
+                  );
+                  computedDiff.left.forEach(l => { l.flattenPath = currentFlattenPath; });
+                  computedDiff.right.forEach(r => { r.flattenPath = currentFlattenPath; });
+                  right.value = computedDiff.right;
+                  left.value = computedDiff.left;
+                }
               }
             }
           }
@@ -734,8 +593,10 @@ const computeLineInformation = (
           right.lineNumber = rightLineNumber;
           right.type = DiffType.ADDED;
           right.value = line;
+          right.flattenPath = currentFlattenPath;
         }
       } else {
+        // default lines
         if (diffArray[diffIndex].count === -1 || diffArray[diffIndex].count >= 0) {
           leftLineNumber += 1;
           rightLineNumber += 1;
@@ -745,9 +606,11 @@ const computeLineInformation = (
           right.type = DiffType.DEFAULT;
           left.value = line;
           right.value = line;
+          left.flattenPath = currentFlattenPath;
+          right.flattenPath = currentFlattenPath;
           if (noised) {
-            left.type = DiffType.NOISED
-            right.type = DiffType.NOISED
+            left.type = DiffType.NOISED;
+            right.type = DiffType.NOISED;
           }
         } else if (diffArray[diffIndex].count === -2) {
           const tagStartIndex = value.indexOf('_keploy_|_keploy_');
@@ -760,31 +623,28 @@ const computeLineInformation = (
           right.type = DiffType.DEFAULT;
           left.value = line.substring(0, tagStartIndex);
           right.value = line.substring(tagStartIndex + tagLength);
+          left.flattenPath = currentFlattenPath;
+          right.flattenPath = currentFlattenPath;
           if (noised) {
-            left.type = DiffType.NOISED
-            right.type = DiffType.NOISED
+            left.type = DiffType.NOISED;
+            right.type = DiffType.NOISED;
           }
         }
       }
       counter += 1;
       return { right, left };
-    }).filter(Boolean);
+    }).filter((item): item is LineInformation => Boolean(item));
   };
 
-
-  diffArray.forEach(({ added, removed, value, noised }: DiffChange, index): void => {
+  diffArray.forEach(({ added, removed, value, noised, flattenPath }, index): void => {
     lineInformation = [
       ...lineInformation,
       ...getLineInformation(value, index, added, removed, noised),
     ];
   });
-  // if (lineInformation.length === 1) {
-  //   lineInformation.push({left: {value: "", lineNumber: 2, type:DiffType.DEFAULT}})
-  // }
+
   return {
     lineInformation,
     diffLines,
   };
 };
-
-export { computeLineInformation };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,39 +25,26 @@ export enum LineNumberPrefix {
 }
 
 export interface ReactDiffViewerProps {
-	// Old value to compare.
-	oldValue: string;
-	// New value to compare.
-	newValue: string;
-	noise: string[];
-	// Enable/Disable split view.
-	splitView?: boolean;
-	// Set line Offset
-	linesOffset?: number;
-	// Enable/Disable word diff.
-	disableWordDiff?: boolean;
-	// JsDiff text diff method from https://github.com/kpdecker/jsdiff/tree/v4.0.1#api
-	compareMethod?: DiffMethod | ((oldStr: string, newStr: string) => Change[]);
-	// Number of unmodified lines surrounding each line diff.
-	extraLinesSurroundingDiff?: number;
-	// Show/hide line number.
-	hideLineNumbers?: boolean;
-	// Show only diff between the two values.
-	showDiffOnly?: boolean;
-	// Render prop to format final string before displaying them in the UI.
-	renderContent?: (source: string) => JSX.Element;
-	// Render prop to format code fold message.
-	codeFoldMessageRenderer?: (
-		totalFoldedLines: number,
-		leftStartLineNumber: number,
-		rightStartLineNumber: number,
-	) => JSX.Element;
-	// Event handler for line number click.
-	onLineNumberClick?: (
-		lineId: string,
-		event: React.MouseEvent<HTMLTableCellElement>,
-	) => void;
-  //renderGutter
+  oldValue: string;
+  newValue: string;
+  noise: string[];
+  splitView?: boolean;
+  linesOffset?: number;
+  disableWordDiff?: boolean;
+  compareMethod?: DiffMethod | ((oldStr: string, newStr: string) => Change[]);
+  extraLinesSurroundingDiff?: number;
+  hideLineNumbers?: boolean;
+  showDiffOnly?: boolean;
+  renderContent?: (source: string) => JSX.Element;
+  codeFoldMessageRenderer?: (
+    totalFoldedLines: number,
+    leftStartLineNumber: number,
+    rightStartLineNumber: number,
+  ) => JSX.Element;
+  onLineNumberClick?: (
+    lineId: string,
+    event: React.MouseEvent<HTMLTableCellElement>,
+  ) => void;
   renderGutter?: (data: {
     lineNumber: number;
     type: DiffType;
@@ -66,64 +53,56 @@ export interface ReactDiffViewerProps {
     additionalLineNumber: number;
     additionalPrefix: LineNumberPrefix;
     styles: ReactDiffViewerStyles;
+    flattenPath: string; // Added flattenPath here
   }) => JSX.Element;
-	// Array of line ids to highlight lines.
-	highlightLines?: string[];
-	// Style overrides.
-	styles?: ReactDiffViewerStylesOverride;
-	// Use dark theme.
-	useDarkTheme?: boolean;
-	// Title for left column
-	leftTitle?: string | JSX.Element;
-	// Title for left column
-	rightTitle?: string | JSX.Element;
+  highlightLines?: string[];
+  styles?: ReactDiffViewerStylesOverride;
+  useDarkTheme?: boolean;
+  leftTitle?: string | JSX.Element;
+  rightTitle?: string | JSX.Element;
 }
 
 export interface ReactDiffViewerState {
-  // Array holding the expanded code folding.
   expandedBlocks?: number[];
 }
 
-class DiffViewer extends React.Component<
-  ReactDiffViewerProps,
-  ReactDiffViewerState
-> {
+class DiffViewer extends React.Component<ReactDiffViewerProps, ReactDiffViewerState> {
   private styles: ReactDiffViewerStyles;
 
-	public static defaultProps: ReactDiffViewerProps = {
-		oldValue: '',
-		newValue: '',
-		noise: [],
-		splitView: true,
-		highlightLines: [],
-		disableWordDiff: false,
-		compareMethod: DiffMethod.CHARS,
-		styles: {},
-		hideLineNumbers: false,
-		extraLinesSurroundingDiff: 3,
-		showDiffOnly: true,
-		useDarkTheme: false,
-		linesOffset: 0,
-	};
+  public static defaultProps: ReactDiffViewerProps = {
+    oldValue: '',
+    newValue: '',
+    noise: [],
+    splitView: true,
+    highlightLines: [],
+    disableWordDiff: false,
+    compareMethod: DiffMethod.CHARS,
+    styles: {},
+    hideLineNumbers: false,
+    extraLinesSurroundingDiff: 3,
+    showDiffOnly: true,
+    useDarkTheme: false,
+    linesOffset: 0,
+  };
 
-	public static propTypes = {
-		oldValue: PropTypes.string.isRequired,
-		newValue: PropTypes.string.isRequired,
-		noise: PropTypes.arrayOf(PropTypes.string),
-		splitView: PropTypes.bool,
-		disableWordDiff: PropTypes.bool,
-		compareMethod: PropTypes.oneOfType([PropTypes.oneOf(Object.values(DiffMethod)), PropTypes.func]),
-		renderContent: PropTypes.func,
-		onLineNumberClick: PropTypes.func,
-		extraLinesSurroundingDiff: PropTypes.number,
-		styles: PropTypes.object,
-		hideLineNumbers: PropTypes.bool,
-		showDiffOnly: PropTypes.bool,
-		highlightLines: PropTypes.arrayOf(PropTypes.string),
-		leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-		linesOffset: PropTypes.number,
-	};
+  public static propTypes = {
+    oldValue: PropTypes.string.isRequired,
+    newValue: PropTypes.string.isRequired,
+    noise: PropTypes.arrayOf(PropTypes.string),
+    splitView: PropTypes.bool,
+    disableWordDiff: PropTypes.bool,
+    compareMethod: PropTypes.oneOfType([PropTypes.oneOf(Object.values(DiffMethod)), PropTypes.func]),
+    renderContent: PropTypes.func,
+    onLineNumberClick: PropTypes.func,
+    extraLinesSurroundingDiff: PropTypes.number,
+    styles: PropTypes.object,
+    hideLineNumbers: PropTypes.bool,
+    showDiffOnly: PropTypes.bool,
+    highlightLines: PropTypes.arrayOf(PropTypes.string),
+    leftTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    rightTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    linesOffset: PropTypes.number,
+  };
 
   public constructor(props: ReactDiffViewerProps) {
     super(props);
@@ -133,10 +112,6 @@ class DiffViewer extends React.Component<
     };
   }
 
-  /**
-   * Resets code block expand to the initial stage. Will be exposed to the parent component via
-   * refs.
-   */
   public resetCodeBlocks = (): boolean => {
     if (this.state.expandedBlocks.length > 0) {
       this.setState({
@@ -147,10 +122,6 @@ class DiffViewer extends React.Component<
     return false;
   };
 
-  /**
-   * Pushes the target expanded code block to the state. During the re-render,
-   * this value is used to expand/fold unmodified code.
-   */
   private onBlockExpand = (id: number): void => {
     const prevState = this.state.expandedBlocks.slice();
     prevState.push(id);
@@ -160,23 +131,11 @@ class DiffViewer extends React.Component<
     });
   };
 
-  /**
-   * Computes final styles for the diff viewer. It combines the default styles with the user
-   * supplied overrides. The computed styles are cached with performance in mind.
-   *
-   * @param styles User supplied style overrides.
-   */
   private computeStyles: (
     styles: ReactDiffViewerStylesOverride,
     useDarkTheme: boolean,
   ) => ReactDiffViewerStyles = memoize(computeStyles);
 
-  /**
-   * Returns a function with clicked line number in the closure. Returns an no-op function when no
-   * onLineNumberClick handler is supplied.
-   *
-   * @param id Line id of a line.
-   */
   private onLineNumberClickProxy = (id: string): any => {
     if (this.props.onLineNumberClick) {
       return (e: any): void => this.props.onLineNumberClick(id, e);
@@ -184,12 +143,6 @@ class DiffViewer extends React.Component<
     return (): void => {};
   };
 
-  /**
-   * Maps over the word diff and constructs the required React elements to show word diff.
-   *
-   * @param diffArray Word diff information derived from line information.
-   * @param renderer Optional renderer to format diff words. Useful for syntax highlighting.
-   */
   private renderWordDiff = (
     diffArray: DiffInformation[],
     renderer?: (chunk: string) => JSX.Element,
@@ -203,6 +156,7 @@ class DiffViewer extends React.Component<
             [this.styles.wordRemoved]: wordDiff.type === DiffType.REMOVED,
             [this.styles.wordNoised]: wordDiff.type === DiffType.NOISED,
           })}
+          data-flattenpath={wordDiff.flattenPath || ''}
         >
           {renderer ? renderer(wordDiff.value as string) : wordDiff.value}
         </span>
@@ -210,24 +164,12 @@ class DiffViewer extends React.Component<
     });
   };
 
-  /**
-   * Maps over the line diff and constructs the required react elements to show line diff. It calls
-   * renderWordDiff when encountering word diff. This takes care of both inline and split view line
-   * renders.
-   *
-   * @param lineNumber Line number of the current line.
-   * @param type Type of diff of the current line.
-   * @param prefix Unique id to prefix with the line numbers.
-   * @param value Content of the line. It can be a string or a word diff array.
-   * @param additionalLineNumber Additional line number to be shown. Useful for rendering inline
-   *  diff view. Right line number will be passed as additionalLineNumber.
-   * @param additionalPrefix Similar to prefix but for additional line number.
-   */
   private renderLine = (
     lineNumber: number,
     type: DiffType,
     prefix: LineNumberPrefix,
     value: string | DiffInformation[],
+    flattenPath?: string,
     additionalLineNumber?: number,
     additionalPrefix?: LineNumberPrefix,
   ): JSX.Element => {
@@ -252,16 +194,15 @@ class DiffViewer extends React.Component<
       <React.Fragment>
         {!this.props.hideLineNumbers && (
           <td
-            onClick={
-              lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)
-            }
+            onClick={lineNumber && this.onLineNumberClickProxy(lineNumberTemplate)}
             className={cn(this.styles.gutter, {
               [this.styles.emptyGutter]: !lineNumber,
               [this.styles.diffAdded]: added,
               [this.styles.diffRemoved]: removed,
-              [this.styles.diffNoised]:noised,
+              [this.styles.diffNoised]: noised,
               [this.styles.highlightedGutter]: highlightLine,
             })}
+            data-flattenpath={flattenPath || ''}
           >
             <pre className={this.styles.lineNumber}>{lineNumber}</pre>
           </td>
@@ -278,6 +219,7 @@ class DiffViewer extends React.Component<
               [this.styles.diffNoised]: noised,
               [this.styles.highlightedGutter]: highlightLine,
             })}
+            data-flattenpath={flattenPath || ''}
           >
             <pre className={this.styles.lineNumber}>{additionalLineNumber}</pre>
           </td>
@@ -291,6 +233,7 @@ class DiffViewer extends React.Component<
               additionalLineNumber,
               additionalPrefix,
               styles: this.styles,
+              flattenPath: flattenPath || '', // Pass flattenPath here
             })
           : null}
         <td
@@ -301,6 +244,7 @@ class DiffViewer extends React.Component<
             [this.styles.diffNoised]: noised,
             [this.styles.highlightedLine]: highlightLine,
           })}
+          data-flattenpath={flattenPath || ''}
         >
           <pre>
             {added && '+'}
@@ -315,27 +259,21 @@ class DiffViewer extends React.Component<
             [this.styles.diffNoised]: noised,
             [this.styles.highlightedLine]: highlightLine,
           })}
+          data-flattenpath={flattenPath || ''}
         >
-          <pre className={cn(this.styles.contentText,{
-            [this.styles.wordNoised]: noised
-            })}>{content}</pre>
+          <pre
+            className={cn(this.styles.contentText, {
+              [this.styles.wordNoised]: noised,
+            })}
+          >
+            {content}
+          </pre>
         </td>
       </React.Fragment>
     );
   };
 
-  /**
-   * Generates lines for split view.
-   *
-   * @param obj Line diff information.
-   * @param obj.left Life diff information for the left pane of the split view.
-   * @param obj.right Life diff information for the right pane of the split view.
-   * @param index React key for the lines.
-   */
-  private renderSplitView = (
-    { left, right }: LineInformation,
-    index: number,
-  ): JSX.Element => {
+  private renderSplitView = ({ left, right }: LineInformation, index: number): JSX.Element => {
     return (
       <tr key={index} className={this.styles.line}>
         {this.renderLine(
@@ -343,30 +281,20 @@ class DiffViewer extends React.Component<
           left.type,
           LineNumberPrefix.LEFT,
           left.value,
+          left.flattenPath,
         )}
         {this.renderLine(
           right.lineNumber,
           right.type,
           LineNumberPrefix.RIGHT,
           right.value,
+          right.flattenPath,
         )}
       </tr>
     );
   };
 
-  /**
-   * Generates lines for inline view.
-   *
-   * @param obj Line diff information.
-   * @param obj.left Life diff information for the added section of the inline view.
-   * @param obj.right Life diff information for the removed section of the inline view.
-   * @param index React key for the lines.
-   */
-  public renderInlineView = (
-    { left, right }: LineInformation,
-    index: number,
-  ): JSX.Element => {
-    let content;
+  public renderInlineView = ({ left, right }: LineInformation, index: number): JSX.Element => {
     if (left.type === DiffType.REMOVED && right.type === DiffType.ADDED) {
       return (
         <React.Fragment key={index}>
@@ -376,7 +304,7 @@ class DiffViewer extends React.Component<
               left.type,
               LineNumberPrefix.LEFT,
               left.value,
-              null,
+              left.flattenPath,
             )}
           </tr>
           <tr className={this.styles.line}>
@@ -385,18 +313,22 @@ class DiffViewer extends React.Component<
               right.type,
               LineNumberPrefix.RIGHT,
               right.value,
+              right.flattenPath,
               right.lineNumber,
             )}
           </tr>
         </React.Fragment>
       );
     }
+
+    let content;
     if (left.type === DiffType.REMOVED) {
       content = this.renderLine(
         left.lineNumber,
         left.type,
         LineNumberPrefix.LEFT,
         left.value,
+        left.flattenPath,
         null,
       );
     }
@@ -406,6 +338,7 @@ class DiffViewer extends React.Component<
         left.type,
         LineNumberPrefix.LEFT,
         left.value,
+        left.flattenPath,
         right.lineNumber,
         LineNumberPrefix.RIGHT,
       );
@@ -416,6 +349,7 @@ class DiffViewer extends React.Component<
         right.type,
         LineNumberPrefix.RIGHT,
         right.value,
+        right.flattenPath,
         right.lineNumber,
       );
     }
@@ -427,25 +361,11 @@ class DiffViewer extends React.Component<
     );
   };
 
-  /**
-   * Returns a function with clicked block number in the closure.
-   *
-   * @param id Cold fold block id.
-   */
   private onBlockClickProxy =
     (id: number): any =>
     (): void =>
       this.onBlockExpand(id);
 
-  /**
-   * Generates cold fold block. It also uses the custom message renderer when available to show
-   * cold fold messages.
-   *
-   * @param num Number of skipped lines between two blocks.
-   * @param blockNumber Code fold block id.
-   * @param leftBlockLineNumber First left line number after the current code fold block.
-   * @param rightBlockLineNumber First right line number after the current code fold block.
-   */
   private renderSkippedLineIndicator = (
     num: number,
     blockNumber: number,
@@ -454,11 +374,7 @@ class DiffViewer extends React.Component<
   ): JSX.Element => {
     const { hideLineNumbers, splitView } = this.props;
     const message = this.props.codeFoldMessageRenderer ? (
-      this.props.codeFoldMessageRenderer(
-        num,
-        leftBlockLineNumber,
-        rightBlockLineNumber,
-      )
+      this.props.codeFoldMessageRenderer(num, leftBlockLineNumber, rightBlockLineNumber)
     ) : (
       <pre className={this.styles.codeFoldContent}>Expand {num} lines ...</pre>
     );
@@ -476,16 +392,13 @@ class DiffViewer extends React.Component<
         className={this.styles.codeFold}
       >
         {!hideLineNumbers && <td className={this.styles.codeFoldGutter} />}
-        {this.props.renderGutter ? (
-          <td className={this.styles.codeFoldGutter} />
-        ) : null}
+        {this.props.renderGutter ? <td className={this.styles.codeFoldGutter} /> : null}
         <td
           className={cn({
             [this.styles.codeFoldGutter]: isUnifiedViewWithoutLineNumbers,
           })}
         />
 
-        {/* Swap columns only for unified view without line numbers */}
         {isUnifiedViewWithoutLineNumbers ? (
           <React.Fragment>
             <td />
@@ -499,89 +412,81 @@ class DiffViewer extends React.Component<
           </React.Fragment>
         )}
 
-				<td />
-				<td />ReactDiffView
-			</tr>
-		);
-	};
-
-	/**
-	 * Generates the entire diff view.
-	 */
-	private renderDiff = (): JSX.Element[] => {
-		const {
-			oldValue,
-			newValue,
-			noise,
-			splitView,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		} = this.props;
-		const { lineInformation, diffLines } = computeLineInformation(
-			oldValue,
-			newValue,
-			noise,
-			disableWordDiff,
-			compareMethod,
-			linesOffset,
-		);
-
-		const extraLines =
-			this.props.extraLinesSurroundingDiff < 0
-				? 0
-				: this.props.extraLinesSurroundingDiff;
-		let skippedLines: number[] = [];
-		return lineInformation.map(
-			(line: LineInformation, i: number): JSX.Element => {
-				const diffBlockStart = diffLines[0];
-				const currentPosition = diffBlockStart - i;
-				if (this.props.showDiffOnly) {
-					if (currentPosition === -extraLines) {
-						skippedLines = [];
-						diffLines.shift();
-					}
-					if (
-						line.left.type === DiffType.DEFAULT &&
-						(currentPosition > extraLines ||
-							typeof diffBlockStart === 'undefined') &&
-						!this.state.expandedBlocks.includes(diffBlockStart)
-					) {
-						skippedLines.push(i + 1);
-						if (i === lineInformation.length - 1 && skippedLines.length > 1) {
-							return this.renderSkippedLineIndicator(
-								skippedLines.length,
-								diffBlockStart,
-								line.left.lineNumber,
-								line.right.lineNumber,
-							);
-						}
-						return null;
-					}
-				}
-
-        const diffNodes = splitView
-          ? this.renderSplitView(line, i)
-          : this.renderInlineView(line, i);
-
-        if (currentPosition === extraLines && skippedLines.length > 0) {
-          const { length } = skippedLines;
-          skippedLines = [];
-          return (
-            <React.Fragment key={i}>
-              {this.renderSkippedLineIndicator(
-                length,
-                diffBlockStart,
-                line.left.lineNumber,
-                line.right.lineNumber,
-              )}
-              {diffNodes}
-            </React.Fragment>
-          );
-        }
-        return diffNodes;
-      },
+        <td />
+        <td />
+      </tr>
     );
+  };
+
+  private renderDiff = (): JSX.Element[] => {
+    const {
+      oldValue,
+      newValue,
+      noise,
+      splitView,
+      disableWordDiff,
+      compareMethod,
+      linesOffset,
+    } = this.props;
+    const { lineInformation, diffLines } = computeLineInformation(
+      oldValue,
+      newValue,
+      noise,
+      disableWordDiff,
+      compareMethod,
+      linesOffset,
+    );
+
+    const extraLines =
+      this.props.extraLinesSurroundingDiff < 0 ? 0 : this.props.extraLinesSurroundingDiff;
+    let skippedLines: number[] = [];
+    return lineInformation.map((line: LineInformation, i: number): JSX.Element => {
+      const diffBlockStart = diffLines[0];
+      const currentPosition = diffBlockStart - i;
+      if (this.props.showDiffOnly) {
+        if (currentPosition === -extraLines) {
+          skippedLines = [];
+          diffLines.shift();
+        }
+        if (
+          line.left.type === DiffType.DEFAULT &&
+          (currentPosition > extraLines || typeof diffBlockStart === 'undefined') &&
+          !this.state.expandedBlocks.includes(diffBlockStart)
+        ) {
+          skippedLines.push(i + 1);
+          if (i === lineInformation.length - 1 && skippedLines.length > 1) {
+            return this.renderSkippedLineIndicator(
+              skippedLines.length,
+              diffBlockStart,
+              line.left.lineNumber,
+              line.right.lineNumber,
+            );
+          }
+          return null;
+        }
+      }
+
+      const diffNodes = splitView
+        ? this.renderSplitView(line, i)
+        : this.renderInlineView(line, i);
+
+      if (currentPosition === extraLines && skippedLines.length > 0) {
+        const { length } = skippedLines;
+        skippedLines = [];
+        return (
+          <React.Fragment key={i}>
+            {this.renderSkippedLineIndicator(
+              length,
+              diffBlockStart,
+              line.left.lineNumber,
+              line.right.lineNumber,
+            )}
+            {diffNodes}
+          </React.Fragment>
+        );
+      }
+      return diffNodes;
+    });
   };
 
   public render = (): JSX.Element => {
@@ -609,8 +514,7 @@ class DiffViewer extends React.Component<
       <tr>
         <td
           colSpan={
-            (splitView ? colSpanOnSplitView : colSpanOnInlineView) +
-            columnExtension
+            (splitView ? colSpanOnSplitView : colSpanOnInlineView) + columnExtension
           }
           className={this.styles.titleBlock}
         >


### PR DESCRIPTION
The main change is ensuring that when we traverse arrays, we append the array index to flattenKeyPath, producing paths like body[0].city instead of body.city.